### PR TITLE
Fix redis dependency type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1759,8 +1759,7 @@
     "denque": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==",
-      "dev": true
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
     },
     "depcheck": {
       "version": "1.2.0",
@@ -5460,7 +5459,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/redis/-/redis-3.0.2.tgz",
       "integrity": "sha512-PNhLCrjU6vKVuMOyFu7oSP296mwBkcE6lrAjruBYG5LgdSqtRBoVQIylrMyVZD/lkF24RSNNatzvYag6HRBHjQ==",
-      "dev": true,
       "requires": {
         "denque": "^1.4.1",
         "redis-commands": "^1.5.0",
@@ -5471,14 +5469,12 @@
     "redis-commands": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.6.0.tgz",
-      "integrity": "sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ==",
-      "dev": true
+      "integrity": "sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ=="
     },
     "redis-errors": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
-      "dev": true
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
     },
     "redis-mock": {
       "version": "0.51.0",
@@ -5489,7 +5485,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
       "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
-      "dev": true,
       "requires": {
         "redis-errors": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lodash": "^4.17.20",
     "pg-format": "^1.0.4",
     "pg-promise": "^10.6.1",
+    "redis": "^3.0.2",
     "redis-mock": "^0.51.0",
     "skhema": "^5.3.3",
     "traverse": "^0.6.6",
@@ -62,7 +63,6 @@
     "husky": "^4.2.5",
     "jsdoc-to-markdown": "^6.0.1",
     "lint-staged": "^10.2.13",
-    "redis": "^3.0.2",
     "shellcheck": "^0.4.4",
     "uuid": "^8.3.0"
   },


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Move `redis` dependency from a devDependency to production dependency