### PR TITLE
Don't error out in post-query processing if `linkedCards` is nullish

### DIFF
--- a/lib/backend/postgres/index.js
+++ b/lib/backend/postgres/index.js
@@ -130,7 +130,7 @@ const postProcessCard = (card) => {
 			// `f1` and `f2` are how postgres denotes the first and second
 			// elements of an anonymous tuple, respectively
 			_.remove(linkedCards, [ 'f1', null ])
-			if (linkedCards.length === 0) {
+			if (!linkedCards || linkedCards.length === 0) {
 				Reflect.deleteProperty(cardLinks, linkType)
 			} else {
 				cardLinks[linkType] = linkedCards.map((tuple) => {


### PR DESCRIPTION
This patch is a temporary stopgap as this case should never happen in the first place.
    
Change-type: patch
Signed-off-by: Carol Schulze <carol@ereski.org>