### PR TITLE
Run all tests with make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ export REDIS_PORT
 REDIS_HOST ?= localhost
 export REDIS_HOST
 
+FILES ?= "'./test/{unit,integration}/**/*.spec.js'"
+export FILES
+
 # -----------------------------------------------
 # Rules
 # -----------------------------------------------


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Run all unit and integration tests with `make test` by setting the default of `FILES` to a glob of all test files.