### PR TITLE
Add common UI Schema entities

### DIFF
--- a/lib/cards/mixins/ui-schema-defs.json
+++ b/lib/cards/mixins/ui-schema-defs.json
@@ -1,0 +1,81 @@
+{
+  "repository": {
+    "ui:widget": "Link",
+    "ui:options": {
+      "blank": true,
+      "href": "https://github.com/${source}"
+    }
+  },
+  "time": {
+    "ui:options": {
+      "dtFormat": "HH:mm"
+    }
+  },
+  "date": {
+    "ui:options": {
+      "dtFormat": "MMM Do, yyyy"
+    }
+  },
+  "dateTime": {
+    "ui:options": {
+      "dtFormat": "MMM Do, yyyy HH:mm"
+    }
+  },
+  "email": {
+    "ui:widget": {
+      "$if": "typeof(source) == \"string\"",
+      "then": "Link",
+      "else": "Array"
+    },
+    "items": {
+      "ui:widget": "Link"
+    }
+  },
+  "badgeList": {
+    "items": {
+      "ui:widget": "Badge"
+    }
+  },
+  "mirrors": {
+    "items": {
+      "ui:widget": "Link",
+      "ui:options": {
+        "blank": true,
+        "href": "${fns.getMirror(source)}"
+      }
+    }
+  },
+  "usernameList": {
+    "ui:options": {
+      "orientation": "horizontal"
+    },
+    "items": {
+      "ui:widget": "Link",
+      "ui:value": "${source[5:]},",
+      "ui:options": {
+        "mr": 1,
+        "href": "https://jel.ly.fish/${source}"
+      }
+    }
+  },
+  "groupList": {
+    "ui:widget": "Txt"
+  },
+  "idOrSlugLink": {
+    "ui:widget": "Link",
+    "ui:options": {
+      "href": "https://jel.ly.fish/${source}"
+    }
+  },
+  "idOrSlugList": {
+    "items": {
+      "$ref": "#/idOrSlugLink"
+    }
+  },
+  "externalUrl": {
+    "ui:widget": "Link",
+    "ui:options": {
+      "blank": true
+    }
+  }
+}

--- a/lib/cards/mixins/with-ui-schema.js
+++ b/lib/cards/mixins/with-ui-schema.js
@@ -11,6 +11,13 @@ module.exports = {
 		uiSchema: {
 			// Only display the data field for the fields UI schema mode
 			fields: {
+				data: {
+					'ui:title': null,
+					origin: null,
+					translateDate: null,
+					$$localSchema: null
+				},
+				id: null,
 				name: null,
 				slug: null,
 				type: null,
@@ -18,6 +25,9 @@ module.exports = {
 				markers: null,
 				tags: null,
 				links: null,
+				linked_at: null,
+				created_at: null,
+				updated_at: null,
 				active: null,
 				requires: null,
 				capabilities: null

--- a/lib/cards/user.js
+++ b/lib/cards/user.js
@@ -4,6 +4,8 @@
  * Proprietary and confidential.
  */
 
+/* eslint-disable no-template-curly-in-string */
+
 module.exports = {
 	slug: 'user',
 	type: 'type@1.0.0',
@@ -202,6 +204,7 @@ module.exports = {
 									format: 'uuid'
 								},
 								sendCommand: {
+									description: 'Command to send a message',
 									type: 'string',
 									default: 'shift+enter',
 									enum: [
@@ -265,6 +268,52 @@ module.exports = {
 				'slug',
 				'data'
 			]
+		},
+		uiSchema: {
+			fields: {
+				data: {
+					hash: null,
+					email: {
+						$ref: `${__dirname}/mixins/ui-schema-defs.json#/email`
+					},
+					status: {
+						'ui:title': null,
+						value: null,
+						title: {
+							'ui:title': 'Current status'
+						}
+					},
+					roles: {
+						items: {
+							'ui:widget': 'Badge'
+						}
+					},
+					avatar: {
+						'ui:widget': 'Img',
+						'ui:options': {
+							width: 100,
+							alt: 'Avatar'
+						}
+					},
+					profile: {
+						'ui:description': null,
+						viewSettings: null,
+						homeView: {
+							$ref: `${__dirname}/mixins/ui-schema-defs.json#/idOrSlugLink`
+						},
+						sendCommand: {
+							'ui:widget': 'Markdown',
+							'ui:value': '`${source}`'
+						},
+						starredViews: {
+							$ref: `${__dirname}/mixins/ui-schema-defs.json#/idOrSlugList`
+						},
+						name: {
+							'ui:title': null
+						}
+					}
+				}
+			}
 		},
 		meta: {
 			relationships: [


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

---

These definitions will be (re-)used by UI schemas in the default cards in the server app.

I've also updated the UI schema for the user. This won't be used yet until [Jellyfish PR 4665](https://github.com/product-os/jellyfish/pull/4665) is merged.