### PR TITLE
Minor UI schema fixes

### DIFF
--- a/lib/cards/mixins/ui-schema-defs.json
+++ b/lib/cards/mixins/ui-schema-defs.json
@@ -13,12 +13,12 @@
   },
   "date": {
     "ui:options": {
-      "dtFormat": "MMM Do, yyyy"
+      "dtFormat": "MMM do, yyyy"
     }
   },
   "dateTime": {
     "ui:options": {
-      "dtFormat": "MMM Do, yyyy HH:mm"
+      "dtFormat": "MMM do, yyyy HH:mm"
     }
   },
   "email": {
@@ -27,8 +27,18 @@
       "then": "Link",
       "else": "Array"
     },
+    "ui:options": {
+      "href": {
+        "$if": "typeof(source) == \"string\"",
+        "then": "mailto:${source}",
+        "else": null
+      }
+    },
     "items": {
-      "ui:widget": "Link"
+      "ui:widget": "Link",
+      "ui:options": {
+        "href": "mailto:${source}"
+      }
     }
   },
   "badgeList": {

--- a/lib/cards/user.js
+++ b/lib/cards/user.js
@@ -303,7 +303,11 @@ module.exports = {
 						},
 						sendCommand: {
 							'ui:widget': 'Markdown',
-							'ui:value': '`${source}`'
+							'ui:value': {
+								$if: 'source',
+								then: '`${source}`',
+								else: null
+							}
 						},
 						starredViews: {
 							$ref: `${__dirname}/mixins/ui-schema-defs.json#/idOrSlugList`


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

---

1. Use date formatting as defined by date-fns not moment (as Rendition uses date-fns)
2. Explicitly define the `href` option for email fields
3. Avoid showing the send command backticks if the value is not defined