### PR TITLE
snippet UI schema matches fields UI schema by default

### DIFF
--- a/lib/cards/mixins/with-ui-schema.js
+++ b/lib/cards/mixins/with-ui-schema.js
@@ -33,9 +33,7 @@ module.exports = {
 				capabilities: null
 			},
 			snippet: {
-				$ref: '#/data/uiSchema/fields',
-				name: {},
-				links: {}
+				$ref: '#/data/uiSchema/fields'
 			}
 		}
 	}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

By default the snippet UI schema copies everything from the fields UI schema (and doesn't include the name and links - these are rendered as standard on the `SingleCard` snippet lens anyway).