### PR TITLE
Remove default snippet UI Schema

### DIFF
--- a/lib/cards/mixins/with-ui-schema.js
+++ b/lib/cards/mixins/with-ui-schema.js
@@ -31,9 +31,6 @@ module.exports = {
 				active: null,
 				requires: null,
 				capabilities: null
-			},
-			snippet: {
-				$ref: '#/data/uiSchema/fields'
 			}
 		}
 	}


### PR DESCRIPTION
By default, card types should have no snippet UI schema

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Note: the 'snippet' UI schema is not currently used anywhere so this is a safe change.