### PR TITLE
Add a 'reset' UI schema definition

### DIFF
--- a/lib/cards/mixins/ui-schema-defs.json
+++ b/lib/cards/mixins/ui-schema-defs.json
@@ -1,4 +1,26 @@
 {
+  "reset": {
+    "data": {
+      "ui:title": null,
+      "origin": null,
+      "translateDate": null,
+      "$$localSchema": null
+    },
+    "id": null,
+    "name": null,
+    "slug": null,
+    "type": null,
+    "version": null,
+    "markers": null,
+    "tags": null,
+    "links": null,
+    "linked_at": null,
+    "created_at": null,
+    "updated_at": null,
+    "active": null,
+    "requires": null,
+    "capabilities": null
+  },
   "repository": {
     "ui:widget": "Link",
     "ui:options": {

--- a/lib/cards/mixins/with-ui-schema.js
+++ b/lib/cards/mixins/with-ui-schema.js
@@ -4,34 +4,14 @@
  * Proprietary and confidential.
  */
 
+const uiSchemaDefs = require('./ui-schema-defs.json')
+
 // This mixin defines all common fields in cards that support
 // UI Schemas (i.e. type cards)
 module.exports = {
 	data: {
 		uiSchema: {
-			// Only display the data field for the fields UI schema mode
-			fields: {
-				data: {
-					'ui:title': null,
-					origin: null,
-					translateDate: null,
-					$$localSchema: null
-				},
-				id: null,
-				name: null,
-				slug: null,
-				type: null,
-				version: null,
-				markers: null,
-				tags: null,
-				links: null,
-				linked_at: null,
-				created_at: null,
-				updated_at: null,
-				active: null,
-				requires: null,
-				capabilities: null
-			}
+			fields: uiSchemaDefs.reset
 		}
 	}
 }


### PR DESCRIPTION
This can be used to set the UI schema for all common card fields with one easy $ref.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>