### PR TITLE
Use published version of json-schema-deref-sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4188,8 +4188,9 @@
       }
     },
     "json-schema-deref-sync": {
-      "version": "github:cvent/json-schema-deref-sync#8bdbac1ff3e001a7b459e08229d3aa93f42b5f13",
-      "from": "github:cvent/json-schema-deref-sync#8bdbac1ff3e001a7b459e08229d3aa93f42b5f13",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.14.0.tgz",
+      "integrity": "sha512-yGR1xmhdiD6R0MSrwWcFxQzAj5b3i5Gb/mt5tvQKgFMMeNe0KZYNEN/jWr7G+xn39Azqgcvk4ZKMs8dQl8e4wA==",
       "requires": {
         "clone": "^2.1.2",
         "dag-map": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "fast-equals": "^2.0.0",
     "fast-json-patch": "^2.2.1",
     "json-e": "^4.3.0",
-    "json-schema-deref-sync": "github:cvent/json-schema-deref-sync#8bdbac1ff3e001a7b459e08229d3aa93f42b5f13",
+    "json-schema-deref-sync": "^0.14.0",
     "lodash": "^4.17.20",
     "pg-format": "^1.0.4",
     "pg-promise": "^10.7.1",


### PR DESCRIPTION
The bug fix was finally published!

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Previously we had to reference a specific commit in the GitHub repo as the owner hadn't published the latest changes (bug fixes). But it's now published so we can use the latest published version!