### PR TITLE
Add to and from card slugs to the link card

### DIFF
--- a/lib/cards/link.js
+++ b/lib/cards/link.js
@@ -44,6 +44,9 @@ module.exports = {
 								type: {
 									type: 'string',
 									pattern: '^[a-z0-9-]+@\\d+(\\.\\d+)?(\\.\\d+)?$'
+								},
+								slug: {
+									type: 'string'
 								}
 							}
 						},
@@ -58,6 +61,9 @@ module.exports = {
 								type: {
 									type: 'string',
 									pattern: '^[a-z0-9-]+@\\d+(\\.\\d+)?(\\.\\d+)?$'
+								},
+								slug: {
+									type: 'string'
 								}
 							}
 						}


### PR DESCRIPTION
During the arch call we decided the easiest way to display links in the Timeline would be to query for links where the toId or the fromId match the card id. We then would bring information out of these links to display. So far we have the id and the type in the link card but we want to show the slug instead of the id since this is the human-readable version