### PR TITLE
Use link notation instead of $events keyword

### DIFF
--- a/lib/cards/org.js
+++ b/lib/cards/org.js
@@ -17,7 +17,7 @@ module.exports = {
 					items: {
 						type: 'string'
 					},
-					$$formula: 'AGGREGATE($events, \'tags\')'
+					$$formula: 'AGGREGATE(this.links["is attached to"], PARTIAL(FLIP(PROPERTY), "tags"))'
 				},
 				markers: {
 					type: 'array',


### PR DESCRIPTION
Change-type: major
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Relates to: https://github.com/product-os/jellyfish-jellyscript/pull/127