### PR TITLE
use a fixed alias name for contains/items subqueries in SQL to avoid ambiguities

### DIFF
--- a/lib/backend/postgres/jsonschema2sql/array-contains-filter.js
+++ b/lib/backend/postgres/jsonschema2sql/array-contains-filter.js
@@ -4,7 +4,6 @@
  * Proprietary and confidential.
  */
 
-const pgFormat = require('pg-format')
 const SqlFilter = require('./sql-filter')
 const SqlSelectBuilder = require('./select-builder')
 
@@ -31,7 +30,7 @@ module.exports = class ArrayContainsFilter extends SqlFilter {
 	}
 
 	toSqlInto (builder) {
-		const alias = pgFormat.ident(this.path.getLast())
+		const alias = 'contents'
 		const field = this.path.toSql(builder.getTable())
 		const unnest = this.path.isProcessingJsonProperty ? 'jsonb_array_elements' : 'unnest'
 

--- a/test/integration/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/integration/backend/postgres/jsonschema2sql/index.spec.js
@@ -1577,3 +1577,44 @@ for (const [ name, testCases ] of Object.entries(reqoptTestCases)) {
 		)
 	}
 }
+
+avaTest('should generate unambiguous aliases for subqueries that can\'t use qualified SQL identifiers',
+	async (test) => {
+		const table = 'unambiguous_alias'
+
+		const schema = {
+			properties: {
+				data: {
+					properties: {
+						tags: {
+							contains: {
+								pattern: 'test'
+							}
+						}
+					}
+				}
+			}
+		}
+
+		const elements = [
+			{
+				slug: 'test-1',
+				type: 'card',
+				data: {
+					tags: [ 'test' ]
+				}
+			}
+		]
+
+		const results = await runner({
+			connection: test.context.connection,
+			database: test.context.database,
+			table,
+			elements,
+			schema
+		})
+
+		test.is(results.length, 1)
+		test.deepEqual(results[0].slug, elements[0].slug)
+	}
+)


### PR DESCRIPTION
Currently `ArrayContainsFilter` uses the name of the property (properly quoted) as the alias for the unnested array. Because that alias is not of type `row`, it has to be referred as a plain alias instead of qualified with a table. This creates an ambiguity if the alias is the same as the name of some column, and postgres errors out.

This commit fixes this bug by making the alias fixed (`contents`).