### PR TITLE
Update permissions filter code to use the word "actor" instead of "user"

### DIFF
--- a/lib/permission-filter.js
+++ b/lib/permission-filter.js
@@ -16,10 +16,10 @@ const VERSIONED_CARDS = _.mapKeys(CARDS, (value, key) => {
 	return `${key}@${value.version}`
 })
 
-const applyMarkers = async (context, backend, user, schema) => {
+const applyMarkers = async (context, backend, actor, schema) => {
 	// TODO: Find a way to implement this logic without
 	// hardcoding the admin user
-	if (user.slug === CARDS['user-admin'].slug) {
+	if (actor.slug === CARDS['user-admin'].slug) {
 		return schema
 	}
 
@@ -39,11 +39,11 @@ const applyMarkers = async (context, backend, user, schema) => {
 				properties: {
 					type: {
 						type: 'string',
-						const: 'user@1.0.0'
+						const: actor.type
 					},
 					slug: {
 						type: 'string',
-						const: user.slug
+						const: actor.slug
 					}
 				}
 			}
@@ -60,7 +60,7 @@ const applyMarkers = async (context, backend, user, schema) => {
 		}
 	})
 
-	const markers = _.uniq([ user, ...orgs ].map((card) => {
+	const markers = _.uniq([ actor, ...orgs ].map((card) => {
 		return card.slug
 	}))
 
@@ -145,16 +145,16 @@ exports.unsafeUpsertCard = async (context, backend, card) => {
 }
 
 /**
- * @summary Get the user that corresponds to a session
+ * @summary Get the actor that corresponds to a session
  * @function
  * @private
  *
  * @param {Object} context - execution context
  * @param {Object} backend - backend
  * @param {String} session - session id
- * @returns {Object} user card
+ * @returns {Object} actor card
  */
-exports.getSessionUser = async (context, backend, session) => {
+exports.getSessionActor = async (context, backend, session) => {
 	const sessionCard = await backend.getElementById(context, session)
 
 	assert.USER(context, sessionCard, errors.JellyfishInvalidSession,
@@ -176,19 +176,19 @@ exports.getSessionUser = async (context, backend, session) => {
 }
 
 /**
- * @summary Get the filter schemas for the user's roles
+ * @summary Get the filter schemas for the actor's roles
  * @function
  * @private
  *
  * @param {Object} context - execution context
  * @param {Object} backend - backend
- * @param {Object} user - user card
+ * @param {Object} actor - actor card
  * @returns {Object[]} role schemas
  */
-const getRoleViews = async (context, backend, user) => {
+const getRoleViews = async (context, backend, actor) => {
 	const viewSchemas = []
 
-	for (const role of [ user.slug, ...user.data.roles ]) {
+	for (const role of [ actor.slug, ..._.get(actor, [ 'data', 'roles' ], []) ]) {
 		const roleCard = await backend.getElementBySlug(
 			context, `role-${role}@1.0.0`)
 
@@ -237,22 +237,24 @@ const evalSchema = (object, context) => {
 	return object
 }
 
-const getUserMask = async (context, backend, user) => {
-	const permissionFilters = await getRoleViews(context, backend, user)
-	return applyMarkers(context, backend, user, {
+const getActorMask = async (context, backend, actor) => {
+	const permissionFilters = await getRoleViews(context, backend, actor)
+	return applyMarkers(context, backend, actor, {
 		type: 'object',
 
 		// At least one permission must match
 		anyOf: permissionFilters.map((object) => {
 			return evalSchema(object, {
-				user
+
+				// TODO: Update views to interpolate "actor" instead of "user"
+				user: actor
 			})
 		})
 	})
 }
 
 /**
- * @summary Get the permissions mask for a user
+ * @summary Get the permissions mask for an actor
  * @function
  * @public
  *
@@ -262,8 +264,8 @@ const getUserMask = async (context, backend, user) => {
  * @returns {Object} mask
  */
 exports.getMask = async (context, backend, session) => {
-	return getUserMask(context, backend,
-		await exports.getSessionUser(context, backend, session))
+	return getActorMask(context, backend,
+		await exports.getSessionActor(context, backend, session))
 }
 
 const mergeMaskInLinks = (schema, mask) => {
@@ -310,8 +312,8 @@ const mergeMaskInLinks = (schema, mask) => {
  * @returns {Object} query
  */
 exports.getQuery = async (context, backend, session, schema) => {
-	const user = await exports.getSessionUser(context, backend, session)
-	const mask = await getUserMask(context, backend, user)
+	const actor = await exports.getSessionActor(context, backend, session)
+	const mask = await getActorMask(context, backend, actor)
 
 	// Apply permission mask to links, recursively
 	mergeMaskInLinks(schema, mask)
@@ -319,7 +321,9 @@ exports.getQuery = async (context, backend, session, schema) => {
 	return jsonSchema.merge([
 		mask,
 		evalSchema(schema, {
-			user
+
+			// TODO: Update views to interpolate "actor" instead of "user"
+			user: actor
 		})
 	])
 }

--- a/test/integration/permission-filter.spec.js
+++ b/test/integration/permission-filter.spec.js
@@ -12,8 +12,8 @@ const helpers = require('./helpers')
 ava.serial.before(helpers.before)
 ava.serial.after(helpers.after)
 
-ava('.getSessionUser() should throw if the session is invalid', async (test) => {
-	await test.throwsAsync(permissionFilter.getSessionUser(
+ava('.getSessionActor() should throw if the session is invalid', async (test) => {
+	await test.throwsAsync(permissionFilter.getSessionActor(
 		test.context.context, test.context.backend, '4a962ad9-20b5-4dd8-a707-bf819593cc84', {
 			user: 'cards',
 			session: 'sessions'
@@ -22,7 +22,7 @@ ava('.getSessionUser() should throw if the session is invalid', async (test) => 
 	})
 })
 
-ava('.getSessionUser() should throw if the session actor is invalid', async (test) => {
+ava('.getSessionActor() should throw if the session actor is invalid', async (test) => {
 	const session = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
 		slug: test.context.generateRandomSlug({
 			prefix: 'session'
@@ -34,7 +34,7 @@ ava('.getSessionUser() should throw if the session actor is invalid', async (tes
 		}
 	})
 
-	await test.throwsAsync(permissionFilter.getSessionUser(test.context.context, test.context.backend, session.id, {
+	await test.throwsAsync(permissionFilter.getSessionActor(test.context.context, test.context.backend, session.id, {
 		user: 'cards',
 		session: 'sessions'
 	}), {
@@ -42,7 +42,7 @@ ava('.getSessionUser() should throw if the session actor is invalid', async (tes
 	})
 })
 
-ava('.getSessionUser() should get the session user given the session did not expire', async (test) => {
+ava('.getSessionActor() should get the session user given the session did not expire', async (test) => {
 	const result = await test.context.kernel.insertCard(
 		test.context.context, test.context.kernel.sessions.admin, {
 			slug: test.context.generateRandomSlug({
@@ -72,7 +72,7 @@ ava('.getSessionUser() should get the session user given the session did not exp
 		}
 	})
 
-	const user = await permissionFilter.getSessionUser(test.context.context, test.context.backend, session.id, {
+	const user = await permissionFilter.getSessionActor(test.context.context, test.context.backend, session.id, {
 		user: 'cards',
 		session: 'sessions'
 	})
@@ -82,7 +82,7 @@ ava('.getSessionUser() should get the session user given the session did not exp
 	}, user))
 })
 
-ava('.getSessionUser() should throw if the session expired', async (test) => {
+ava('.getSessionActor() should throw if the session expired', async (test) => {
 	const user = await test.context.kernel.insertCard(
 		test.context.context, test.context.kernel.sessions.admin, {
 			slug: test.context.generateRandomSlug({
@@ -112,7 +112,7 @@ ava('.getSessionUser() should throw if the session expired', async (test) => {
 		}
 	})
 
-	await test.throwsAsync(permissionFilter.getSessionUser(test.context.context, test.context.backend, session.id, {
+	await test.throwsAsync(permissionFilter.getSessionActor(test.context.context, test.context.backend, session.id, {
 		user: 'cards',
 		session: 'sessions'
 	}), {


### PR DESCRIPTION
This change updates the word "user" to "actor" to be more semantically
correct when working with permissions, since contracts that aren't users
can interact with the system.
This doesn't introduce any functional changes apart from making the
system more safe if the actor doesn't have a role field.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>