### PR TITLE
Add array fulltext search

### DIFF
--- a/lib/backend/postgres/cards.js
+++ b/lib/backend/postgres/cards.js
@@ -14,6 +14,7 @@ const metrics = require('@balena/jellyfish-metrics')
 const utils = require('./utils')
 const traverse = require('traverse')
 const textSearch = require('./jsonschema2sql/text-search')
+const SqlPath = require('./jsonschema2sql/sql-path')
 
 const CARDS_TABLE = 'cards'
 const CARDS_TRIGGER_COLUMNS = [
@@ -600,9 +601,11 @@ exports.createFullTextSearchIndex = async (context, connection, type, fields) =>
 	await connection.task(async (task) => {
 		const tasks = []
 		fields.forEach((field) => {
+			const path = SqlPath.fromArray(_.clone(field.path))
+			const isJson = path.isProcessingJsonProperty
 			const name = `${typeBase}__${field.path.join('_')}__search_idx`
 			tasks.push(task.any(`CREATE INDEX IF NOT EXISTS "${name}" ON ${CARDS_TABLE}
-				USING GIN(${textSearch.toTSVector(CARDS_TABLE, field.path, field.isRootArray)})
+				USING GIN(${textSearch.toTSVector(path.toSql(CARDS_TABLE), isJson, field.isArray)})
 				WHERE type=${pgFormat.literal(versionedType)}`))
 
 			logger.info(context, 'Creating search index', {
@@ -651,7 +654,7 @@ exports.parseFullTextSearchFields = (context, schema, errors) => {
 						})) {
 							fields.push({
 								path,
-								isRootArray: false
+								isArray: false
 							})
 						}
 					}
@@ -659,7 +662,7 @@ exports.parseFullTextSearchFields = (context, schema, errors) => {
 			} else {
 				fields.push({
 					path: exports.fromTypePath(_.dropRight(this.path)),
-					isRootArray: exports.isRootArray(this.parent.node.type, this.parent.path)
+					isArray: Boolean(this.parent.node.type === 'array')
 				})
 			}
 		}
@@ -686,21 +689,4 @@ exports.fromTypePath = (from) => {
 	})
 	path.push(target)
 	return path
-}
-
-/**
- * @summary Check if an item is a root-level array
- * @function
- *
- * @param {String} type - item type
- * @param {Array} path - path to item in array format
- * @returns {Boolean} boolean denoting if is root-level array
- *
- * @example
- * const type = 'array'
- * const path = [ 'data', 'schema', 'properties', 'tags' ]
- * const result = exports.isRootArray(type, path)
- */
-exports.isRootArray = (type, path) => {
-	return Boolean(type === 'array' && _.isEqual(_.dropRight(path), [ 'data', 'schema', 'properties' ]))
 }

--- a/lib/backend/postgres/jsonschema2sql/full-text-search-filter.js
+++ b/lib/backend/postgres/jsonschema2sql/full-text-search-filter.js
@@ -28,9 +28,8 @@ module.exports = class FullTextSearchFilter extends SqlFilter {
 	}
 
 	toSqlInto (builder) {
-		const isRootArray = this.asArray && this.path.isProcessingColumn
-		const tsVector = textSearch.toTSVector(
-			builder.getTable(), this.path.asArray(), isRootArray)
+		const tsVector = textSearch.toTSVector(this.path.toSql(builder.getTable()),
+			this.path.isProcessingJsonProperty, this.asArray)
 		const tsQuery = textSearch.toTSQuery(this.term)
 		builder
 			.push(tsVector)

--- a/lib/backend/postgres/jsonschema2sql/sql-query.js
+++ b/lib/backend/postgres/jsonschema2sql/sql-query.js
@@ -580,8 +580,19 @@ module.exports = class SqlQuery {
 			return
 		}
 
-		const containsQuery = this.buildQueryFromCorrelatedSchema(schema, [ 'contains' ])
-		const filter = new ArrayContainsFilter(this.path, containsQuery.filter)
+		let filter = null
+		if (_.has(schema, [ 'fullTextSearch' ])) {
+			assert.INTERNAL(null, _.isPlainObject(schema.fullTextSearch), Error, () => {
+				return `value for '${this.formatJsonPath('fullTextSearch')}' must be a map`
+			})
+			assert.INTERNAL(null, _.isString(schema.fullTextSearch.term), Error, () => {
+				return `value for '${this.formatJsonPath('fullTextSearch')}.term' must be a string`
+			})
+			filter = new FullTextSearchFilter(this.path, schema.fullTextSearch.term, true)
+		} else {
+			const containsQuery = this.buildQueryFromCorrelatedSchema(schema, [ 'contains' ])
+			filter = new ArrayContainsFilter(this.path, containsQuery.filter)
+		}
 		this.filter.and(this.ifTypeThen('array', filter))
 	}
 
@@ -897,7 +908,6 @@ module.exports = class SqlQuery {
 		})
 
 		this.filter.and(this.ifTypeThen('string', new FullTextSearchFilter(this.path, value.term)))
-		this.filter.and(this.ifTypeThen('array', new FullTextSearchFilter(this.path, value.term, true)))
 	}
 
 	ifTypeThen (type, filter) {

--- a/lib/backend/postgres/jsonschema2sql/text-search.js
+++ b/lib/backend/postgres/jsonschema2sql/text-search.js
@@ -4,38 +4,29 @@
  * Proprietary and confidential.
  */
 
-const _ = require('lodash')
 const pgFormat = require('pg-format')
 
 /**
  * @summary Prepare a Postgres to_tsvector function call for full-text search
  * @function
  *
- * @param {String} table - table name
- * @param {Array} path - path to field
- * @param {Boolean} isRootArray - denotes if Postgres text[] column
+ * @param {String} path - full path to field
+ * @param {Boolean} isJson - denotes if json field
+ * @param {Boolean} isArray - denotes if array
  * @returns {String} to_tsvector function call
  *
  * @example
- * const table = 'cards'
- * const path = [ 'data', 'payload', 'message' ]
- * const isRootTextArray = false
- * const result = exports.toTSVector(table, path, isRootTextArray)
+ * const result = exports.toTSVector('cards.tags', false, true)
  */
-exports.toTSVector = (table, path, isRootArray) => {
-	const keys = _.clone(path)
-
-	// Non-JSONB arrays need to be joined into a string before tokenization
-	if (keys.length === 1) {
-		const selector = `${table}.${keys.shift()}`
-		if (isRootArray) {
-			return `to_tsvector('english', immutable_array_to_string(${selector}, ' '))`
-		}
-		return `to_tsvector('english', ${selector})`
+exports.toTSVector = (path, isJson, isArray) => {
+	if (isJson) {
+		return `jsonb_to_tsvector('english', ${path}, '["string"]')`
 	}
 
-	// Anything under data can be handled with jsonb_to_tsvector
-	return `jsonb_to_tsvector('english', ${table}.${keys.shift()}#>'{${keys.join(',')}}', '["string"]')`
+	if (isArray) {
+		return `to_tsvector('english', immutable_array_to_string(${path}, ' '))`
+	}
+	return `to_tsvector('english', ${path})`
 }
 
 /**

--- a/test/unit/backend/postgres/cards.spec.js
+++ b/test/unit/backend/postgres/cards.spec.js
@@ -131,27 +131,27 @@ ava('Should be able to find multiple full-text search fields at various depths f
 	const expected = [
 		{
 			path: [ 'name' ],
-			isRootArray: false
+			isArray: false
 		},
 		{
 			path: [ 'tags' ],
-			isRootArray: true
+			isArray: true
 		},
 		{
 			path: [ 'data', 'approvals' ],
-			isRootArray: false
+			isArray: true
 		},
 		{
 			path: [ 'data', 'observations' ],
-			isRootArray: false
+			isArray: false
 		},
 		{
 			path: [ 'data', 'category' ],
-			isRootArray: false
+			isArray: false
 		},
 		{
 			path: [ 'data', 'payload', 'message' ],
-			isRootArray: false
+			isArray: false
 		}
 	]
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

This PR fixes a bug with the generation of the `to_tsvector` SQL predicate used in fulltext search.

## Problem
The problem was that the parameters being passed to the function that generates this predicate were not always the values that were expected. This PR modifies the logic of the predicate generator to match the `regexp` based search predicate generation, making it a more natural piece of the `jsonschema2sql` compiler and solving the following query problem.

## Broken array search query
The following query work when searching through strings in an array, but does not:
```
{
    "type":"object",
    "additionalProperties":true,
    "required":[
       "active",
       "type"
    ],
    "title":"user-generated-filter",
    "anyOf":[
       {
          "properties":{
             "data":{
                "type":"object",
                "required":[
                   "tags"
                ],
                "properties":{
                   "tags":{
                      "type":"array",
                      "contains": {
                        "type": "string",
                        "fullTextSearch":{
                          "term":"cat"
                        }
                      }
                   }
                }
             }
          },
          "required":[
             "data"
          ]
       }
    ],
    "properties":{
       "type":{
          "type":"string",
          "const":"support-thread@1.0.0"
       },
       "active":{
          "type":"boolean",
          "const":true
       }
    }
}
```

Instead, one would need to fulltext search against the array instead of the array's contains. This PR fixes that problem, making the query structure match that of regexp searches and more valid jsonschema.

## Index Generation
This PR changes the search index generation SQL ever so slightly, by double-quoting jsonb child elements:
### Before
```
CREATE INDEX IF NOT EXISTS "message__data_payload_message__search_idx" ON cards USING GIN(to_tsvector('english', cards.data#>'{payload,message}')) WHERE type='message@1.0.0';
```

### After
```
CREATE INDEX IF NOT EXISTS "message__data_payload_message__search_idx" ON cards USING GIN(to_tsvector('english', cards.data#>'{"payload", "message"}')) WHERE type='message@1.0.0';
```

Because of this slight change, I double-checked the `indexdef` for indexes creating with and without these changes. The end result of both queries results in the same index:
```
jellyfish=# select indexdef from pg_indexes where indexname='support-thread__data_tags__search_idx'; <== before changes
CREATE INDEX "support-thread__data_tags__search_idx" ON public.cards USING gin (jsonb_to_tsvector('english'::regconfig, (data #> '{tags}'::text[]), '["strin
g"]'::jsonb)) WHERE (type = 'support-thread@1.0.0'::text)

jellyfish=# select indexdef from pg_indexes where indexname='message__data_payload_alertsUser__search_idx'; <== after changes
CREATE INDEX "message__data_payload_alertsUser__search_idx" ON public.cards USING gin (jsonb_to_tsvector('english'::regconfig, (data #> '{payload,alertsUser
}'::text[]), '["string"]'::jsonb)) WHERE (type = 'message@1.0.0'::text)

jellyfish=# select indexdef from pg_indexes where indexname='sales-thread__name__search_idx'; <== before changes
CREATE INDEX "sales-thread__name__search_idx" ON public.cards USING gin (to_tsvector('english'::regconfig, name)) WHERE (type = 'sales-thread@1.0.0'::text)

jellyfish=# select indexdef from pg_indexes where indexname='account__name__search_idx'; <== after changes
CREATE INDEX account__name__search_idx ON public.cards USING gin (to_tsvector('english'::regconfig, name)) WHERE (type = 'account@1.0.0'::text)
```

## Index Usage
Also ran a few `EXPLAIN`s against jsonb string array indexes to make sure they are used:
```
select from cards where jsonb_to_tsvector('english', cards.data#>'{"payload", "alertsUser"}', '["string"]') @@ plainto_tsquery('english', 'third') and type='message@1.0.0';

 Bitmap Heap Scan on cards  (cost=12.01..69.62 rows=14 width=0)
   Recheck Cond: ((jsonb_to_tsvector('english'::regconfig, (data #> '{payload,alertsUser}'::text[]), '["string"]'::jsonb) @@ '''third'''::tsquery) AND (type = 'message@1.0.0'::text))
   ->  Bitmap Index Scan on "message__data_payload_alertsUser__search_idx"  (cost=0.00..12.01 rows=14 width=0)
         Index Cond: (jsonb_to_tsvector('english'::regconfig, (data #> '{payload,alertsUser}'::text[]), '["string"]'::jsonb) @@ '''third'''::tsquery)
```