### PR TITLE
Patch cards in transactions

### DIFF
--- a/lib/backend/postgres/index.js
+++ b/lib/backend/postgres/index.js
@@ -20,6 +20,8 @@ const streams = require('./streams')
 const utils = require('./utils')
 const markers = require('./markers')
 const metrics = require('@balena/jellyfish-metrics')
+const uuid = require('@balena/jellyfish-uuid')
+const txMode = require('pg-promise').txMode
 
 /*
  * See https://github.com/product-os/jellyfish/issues/2401
@@ -153,7 +155,7 @@ const postProcessResults = (results) => {
 	}
 }
 
-const queryTable = async (context, backend, table, select, schema, options) => {
+const queryTable = async (context, backend, table, select, schema, options = {}) => {
 	const mode = options.profile ? 'info' : 'debug'
 
 	logger[mode](context, 'Querying from table', {
@@ -177,7 +179,7 @@ const queryTable = async (context, backend, table, select, schema, options) => {
 	const {
 		results,
 		queryTime
-	} = await runQuery(context, schema, query, backend.connection, backend.errors)
+	} = await runQuery(context, schema, query, options.connection || backend.connection, backend.errors)
 
 	const {
 		elements,
@@ -196,9 +198,10 @@ const queryTable = async (context, backend, table, select, schema, options) => {
 	return elements
 }
 
-const upsertObject = async (context, backend, object, options) => {
+const upsertObject = async (context, backend, object, options = {}) => {
+	const connection = options.connection || backend.connection
 	const insertedObject = await cards.upsert(
-		context, backend.errors, backend.connection, object, {
+		context, backend.errors, connection, object, {
 			replace: options.replace
 		})
 
@@ -209,7 +212,7 @@ const upsertObject = async (context, backend, object, options) => {
 	const baseType = insertedObject.type.split('@')[0]
 
 	if (baseType === 'link') {
-		await links.upsert(context, backend.connection, insertedObject)
+		await links.upsert(context, connection, insertedObject)
 
 		// TODO: We only "materialize" links in this way because we haven't
 		// come up with a better way to traverse links while streaming.
@@ -548,10 +551,47 @@ module.exports = class PostgresBackend {
 	 * Insert a card to the database, or replace it
 	 * if a card with the same id or slug already exists.
 	 */
-	async upsertElement (context, object) {
-		return upsertObject(context, this, object, {
+	async upsertElement (context, object, options = {}) {
+		return upsertObject(context, this, object, Object.assign({}, options, {
 			replace: true
+		}))
+	}
+
+	/*
+	 * Execute a provided callback within a transaction.
+	 */
+	async withTransaction (callback, options = {}) {
+		options.tag = `transaction_${uuid.random()}`
+		return this.connection.tx(options, (transaction) => {
+			return callback(transaction)
 		})
+	}
+
+	/*
+	 * Execute a provided callback within a serializable transaction,
+	 * retrying on concurrent update errors.
+	 */
+	async withSerializableTransaction (context, callback, options = {}) {
+		const transactionOptions = Object.assign({}, options, {
+			mode: new txMode.TransactionMode({
+				tiLevel: txMode.isolationLevel.serializable
+			})
+		})
+
+		const attemptTransaction = async () => {
+			return this.withTransaction(callback, transactionOptions)
+				.catch((error) => {
+					if (/serializ/i.test(error.message)) {
+						logger.debug(context, 'Transaction attempt failed', {
+							message: error.message
+						})
+						return attemptTransaction()
+					}
+					throw error
+				})
+		}
+
+		return attemptTransaction()
 	}
 
 	/*
@@ -598,7 +638,8 @@ module.exports = class PostgresBackend {
 	/*
 	 * Get a card from the database by slug and table.
 	 */
-	async getElementBySlug (context, slug) {
+	async getElementBySlug (context, slug, options = {}) {
+		const connection = options.connection || this.connection
 		const [ base, version ] = slug.split('@')
 		assert.INTERNAL(context, version && version !== 'latest',
 			this.errors.JellyfishInvalidVersion,
@@ -608,7 +649,7 @@ module.exports = class PostgresBackend {
 		 * Lets first check the in-memory cache so we can avoid
 		 * making a full-blown query to the database.
 		 */
-		if (this.cache) {
+		if (this.cache && !options.skipCache) {
 			const cacheResult = await this.cache.getBySlug(
 				cards.TABLE, base, version)
 
@@ -621,7 +662,7 @@ module.exports = class PostgresBackend {
 		 * Make a database request if we didn't have luck with
 		 * the cache.
 		 */
-		const result = await cards.getBySlug(context, this.connection, slug)
+		const result = await cards.getBySlug(context, connection, slug)
 
 		if (this.cache) {
 			if (result) {

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -385,9 +385,10 @@ module.exports = class Kernel {
 	 * @param {Object} context - execution context
    * @param {String} session - session id
    * @param {String} slug - card slug
+   * @param {Object} options - optional set of extra options
    * @returns {(Object|Null)} card
    */
-	async getCardBySlug (context, session, slug) {
+	async getCardBySlug (context, session, slug, options = {}) {
 		logger.debug(context, 'Fetching card by slug', {
 			slug
 		})
@@ -402,6 +403,9 @@ module.exports = class Kernel {
 
 		const queryOptions = {
 			limit: 1
+		}
+		if (options.connection) {
+			queryOptions.connection = options.connection
 		}
 
 		const schema = {
@@ -508,83 +512,81 @@ module.exports = class Kernel {
    * @returns {Object} the patched card
    */
 	async patchCardBySlug (context, session, slug, patch) {
+		const filter = await permissionFilter.getMask(context, this.backend, session)
 		const result = await metrics.measureCardPatch(async () => {
-			const fullCard = await this.backend.getElementBySlug(
-				context, slug)
-
-			assert.INTERNAL(context, fullCard,
-				this.errors.JellyfishNoElement,
-				`No such card: ${slug}`)
-
-			// Fetch necessary objects concurrently
-			const [
-				filteredCard,
-				typeCard,
-				filter
-			] = await Promise.all([
-				this.getCardBySlug(
-					context, session, `${fullCard.slug}@${fullCard.version}`),
-				this.getCardBySlug(context, session, fullCard.type),
-				permissionFilter.getMask(context, this.backend, session)
-			])
-
-			if (patch.length === 0) {
-				return filteredCard
-			}
-
-			assert.INTERNAL(context, filteredCard,
-				this.errors.JellyfishNoElement,
-				`No such card: ${slug}`)
-
-			const schema = typeCard && typeCard.data && typeCard.data.schema
-			assert.INTERNAL(context, schema,
-				this.errors.JellyfishUnknownCardType,
-				`Unknown type: ${fullCard.type}`)
-
-			/*
-			 * The idea of this algorithm is that we get the full card
-			 * as stored in the database and the card as the current actor
-			 * can see it. Then we apply the patch to both the full and
-			 * the filtered card, aborting if it fails on any. If it succeeds
-			 * then we upsert the full card to the database, but only
-			 * if the resulting filtered card still matches the permissions
-			 * filter.
-			 */
-
-			const patchedFilteredCard = patchCard(filteredCard, patch, {
-				mutate: true
-			})
-
-			jsonSchema.validate(filter, patchedFilteredCard)
-			const patchedFullCard = patchCard(fullCard, patch, {
-				mutate: false
-			})
-
-			try {
-				jsonSchema.validate(schema, patchedFullCard)
-			} catch (error) {
-				if (error instanceof errors.JellyfishSchemaMismatch) {
-					error.expected = true
-
-					// Because the "full" unrestricted card is being validated there is
-					// potential for an error message to leak private data. To prevent this,
-					// override the detailed error message with a generic one.
-					error.message = 'The updated card is invalid'
+			return this.backend.withSerializableTransaction(context, async (transaction) => {
+				// Set options to ensure subsequent queries are a part of the transaction
+				const options = {
+					connection: transaction,
+					skipCache: true
 				}
 
-				throw error
-			}
+				// Fetch necessary data from database
+				const fullCard = await this.backend.getElementBySlug(context, slug, options)
+				assert.INTERNAL(context, fullCard,
+					this.errors.JellyfishNoElement,
+					`No such card: ${slug}`)
 
-			// Don't do a pointless update
-			if (fastEquals.deepEqual(patchedFullCard, fullCard)) {
-				return fullCard
-			}
+				const filteredCard = await this.getCardBySlug(context, session, `${fullCard.slug}@${fullCard.version}`, options)
+				if (patch.length === 0) {
+					return filteredCard
+				}
 
-			await this.backend.upsertElement(context, patchedFullCard)
+				const typeCard = await this.getCardBySlug(context, session, fullCard.type, options)
+				assert.INTERNAL(context, filteredCard,
+					this.errors.JellyfishNoElement,
+					`No such card: ${slug}`)
 
-			// Otherwise a person that patches a card gets
-			// to see the full card
-			return patchedFilteredCard
+				const schema = typeCard && typeCard.data && typeCard.data.schema
+				assert.INTERNAL(context, schema,
+					this.errors.JellyfishUnknownCardType,
+					`Unknown type: ${fullCard.type}`)
+
+				/*
+				 * The idea of this algorithm is that we get the full card
+				 * as stored in the database and the card as the current actor
+				 * can see it. Then we apply the patch to both the full and
+				 * the filtered card, aborting if it fails on any. If it succeeds
+				 * then we upsert the full card to the database, but only
+				 * if the resulting filtered card still matches the permissions
+				 * filter.
+				 */
+
+				const patchedFilteredCard = patchCard(filteredCard, patch, {
+					mutate: true
+				})
+
+				jsonSchema.validate(filter, patchedFilteredCard)
+				const patchedFullCard = patchCard(fullCard, patch, {
+					mutate: false
+				})
+
+				try {
+					jsonSchema.validate(schema, patchedFullCard)
+				} catch (error) {
+					if (error instanceof errors.JellyfishSchemaMismatch) {
+						error.expected = true
+
+						// Because the "full" unrestricted card is being validated there is
+						// potential for an error message to leak private data. To prevent this,
+						// override the detailed error message with a generic one.
+						error.message = 'The updated card is invalid'
+					}
+
+					throw error
+				}
+
+				// Don't do a pointless update
+				if (fastEquals.deepEqual(patchedFullCard, fullCard)) {
+					return fullCard
+				}
+
+				await this.backend.upsertElement(context, patchedFullCard, options)
+
+				// Otherwise a person that patches a card gets
+				// to see the full card
+				return patchedFilteredCard
+			})
 		})
 		return result
 	}
@@ -632,7 +634,8 @@ module.exports = class Kernel {
 			sortBy: options.sortBy,
 			sortDir: options.sortDir,
 			profile: options.profile,
-			links: options.links
+			links: options.links,
+			connection: options.connection || null
 
 		// For debugging purposes
 		}).catch((error) => {

--- a/test/integration/backend/index.spec.js
+++ b/test/integration/backend/index.spec.js
@@ -30,6 +30,8 @@ ava('should only expose the required methods', (test) => {
 		'reset',
 		'insertElement',
 		'upsertElement',
+		'withTransaction',
+		'withSerializableTransaction',
 		'getElementById',
 		'getElementBySlug',
 		'getElementsById',


### PR DESCRIPTION
Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>

---

This PR will modify the way we patch cards. By patching inside of transactions, we can process concurrent and possibly conflicting updates. Our current logic is vulnerable to race conditions, allowing for newer data to be overwritten by older data under certain circumstances.

This PR:
- adds a generic transaction wrapper method in the backend
- adds a more specific serializable transaction method in the backend
- runs the card patch logic inside of a serializable transaction
- adds `options.connection` to a number of functions allowing us to use the transaction's connection for queries that need to be executed as part of the card patch

## Tests
- [`jellyfish-plugin-default`](https://github.com/product-os/jellyfish-plugin-default/pull/74): [PASS](https://ci.balena-dev.com/builds/703624)
- [`jellyfish`](https://github.com/product-os/jellyfish/pull/5514): [PASS](https://ci.balena-dev.com/builds/703605)