### PR TITLE
Remove database connect attempt limit

### DIFF
--- a/lib/backend/postgres/index.js
+++ b/lib/backend/postgres/index.js
@@ -369,7 +369,7 @@ module.exports = class PostgresBackend {
 				version
 			})
 		} catch (error) {
-			logger.info(context, 'Connection to database failed', {
+			logger.warn(context, 'Connection to database failed', {
 				error
 			})
 			await Bluebird.delay(CONNECT_RETRY_DELAY)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Remove the arbitrary 10 attempts limit when trying to connect to the database, keeping the 2 second delay between attempts. We have `warn` level logs output on every connect attempt failure so that we can easily tell that the service is still not connected to the database. Up until now, we have allowed 10 connect attempt retries and then killed the app. In production, what actually happens is Kubernetes then recreates the failed pod, resulting in infinite connection attempts but not at the application level.

The idea for removing this arbitrary limit came to me while working on the database reconnect on disconnect issue. Reconnect attempts should also be limitless.

(Originally, backend services would die immediately after the first db connection attempt failed. Ironically, I'm the one that came in and gave apps at least 10 more tries before dying, but am now thinking there's no reason to have any kind of limit as long as there's a reasonable delay between attempts.)