### PR TITLE
Reconnect streamer to database on disconnect

### DIFF
--- a/lib/backend/postgres/index.js
+++ b/lib/backend/postgres/index.js
@@ -27,7 +27,7 @@ const metrics = require('@balena/jellyfish-metrics')
 const MAXIMUM_QUERY_LIMIT = 1000
 
 // Amount of time to wait before retrying connect
-const CONNECT_RETRY_DELAY = 2000
+const DEFAULT_CONNECT_RETRY_DELAY = 2000
 
 const queryv2 = {}
 
@@ -322,6 +322,9 @@ module.exports = class PostgresBackend {
 		 * purposes.
 		 */
 		this.database = options.database.toLowerCase()
+
+		// The amount of time in milliseconds to wait before performing subsequent connect/reconnect attempts.
+		this.connectRetryDelay = (_.isNumber(options.connectRetryDelay)) ? options.connectRetryDelay : DEFAULT_CONNECT_RETRY_DELAY
 	}
 
 	/*
@@ -372,7 +375,7 @@ module.exports = class PostgresBackend {
 			logger.warn(context, 'Connection to database failed', {
 				error
 			})
-			await Bluebird.delay(CONNECT_RETRY_DELAY)
+			await Bluebird.delay(this.connectRetryDelay)
 			return this.connect(context)
 		}
 
@@ -437,6 +440,12 @@ module.exports = class PostgresBackend {
 			idleTimeoutMillis: 60 * 1000,
 			database: this.database
 		}))
+		this.connection.$pool.on('error', (error) => {
+			logger.warn(context, 'Backend connection pool error', {
+				code: error.code,
+				message: error.message
+			})
+		})
 
 		try {
 			await cards.setup(context, this.connection, this.database)
@@ -467,7 +476,7 @@ module.exports = class PostgresBackend {
 			}
 		}
 
-		this.streamClient = await streams.start(
+		this.streamClient = await streams.start(context,
 			this, this.connection, cards.TABLE, cards.TRIGGER_COLUMNS)
 
 		return true

--- a/lib/backend/postgres/streams.js
+++ b/lib/backend/postgres/streams.js
@@ -13,6 +13,7 @@ const metrics = require('@balena/jellyfish-metrics')
 const {
 	INIT_LOCK
 } = require('./cards')
+const Bluebird = require('bluebird')
 
 const INSERT_EVENT = 'insert'
 const UPDATE_EVENT = 'update'
@@ -22,9 +23,9 @@ const UNMATCH_EVENT = 'unmatch'
 // Functions cannot be created concurrently
 const CREATE_ROW_CHANGED_FUNCTION_LOCK = 2043989439426746
 
-exports.start = async (backend, connection, table, columns) => {
+exports.start = async (context, backend, connection, table, columns) => {
 	const streamer = new Streamer(backend, table)
-	await streamer.init(await connection.connect(), columns)
+	await streamer.init(context, await connection.connect(), columns, backend.connectRetryDelay)
 
 	return streamer
 }
@@ -119,13 +120,58 @@ class Streamer {
 		this.notificationHandler = async (notification) => {
 			return handleNotification(this, notification)
 		}
+		this.errorHandler = (context, error) => {
+			logger.warn(context, 'Streamer database client error', {
+				code: error.code,
+				message: error.message
+			})
+		}
+		this.endHandler = async (context, columns, connectRetryDelay) => {
+			// Attempt reconnects to database on unexpected client ends.
+			// Expected ends are performed with Streamer.close(), which nullifies "this.connection" before disconnect.
+			if (this.connection) {
+				logger.warn(context, 'Streamer database client disconnected, attempting reconnection')
+				let reconnecting = true
+				while (reconnecting) {
+					try {
+						await this.init(context, await this.backend.connection.connect(), columns, connectRetryDelay)
+						logger.info(context, 'Streamer database client reconnected')
+						reconnecting = false
+					} catch (error) {
+						logger.warn(context, 'Streamer database client reconnect attempt failed', {
+							code: error.code,
+							message: error.message
+						})
+						await Bluebird.delay(connectRetryDelay)
+					}
+				}
+			}
+		}
 	}
 
-	async init (connection, columns) {
+	/**
+	* @summary Initialize a streamer instance, and set up PG notify trigger
+	* @function
+	*
+	* @param {Object} context - execution context
+	* @param {Object} connection - pg.Client instance
+	* @param {Array} columns - list of columns names used for trigger
+	* @param {Number} connectRetryDelay - amount of time (ms) to wait between DB connect attempts
+	*
+	* @example
+	* await streamer.init(context, await connection.connect(), columns, connectRetryDelay)
+	*/
+	async init (context, connection, columns, connectRetryDelay) {
 		this.connection = connection
 
 		await setupTrigger(connection, this.table, columns)
 		connection.client.on('notification', this.notificationHandler)
+		connection.client.on('error', (error) => {
+			this.errorHandler(context, error)
+		})
+		connection.client.on('end', async () => {
+			await this.endHandler(context, columns, connectRetryDelay)
+		})
 	}
 
 	getAttachedStreamCount () {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Resolves https://github.com/product-os/jellyfish/issues/4812

Add Postgres client reconnect on disconnect logic to our PG Notify stream client implementation. Without this, the browser's socket.io client no longer receives card stream updates after the api service is unexpectedly disconnected from Postgres. With this fix, the backend streamer client is automatically reconnected to Postgres as soon as possible, allowing the browser to receive updates without the need to refresh the page.

The current stream client implementation found in `lib/backend/postgres/streams.js` seems to assume that the `pg.Client` object created during the initial stream client creation will never lose connection. `pg.Pool`s automatically attempt reconnects, but `pg.Client`s do not.

## Before
![before](https://user-images.githubusercontent.com/45343541/104092237-ff49e580-52c5-11eb-9f25-1a0864d987dd.gif)

This is what happens without this reconnect logic. When Postgres restarts when the stream client is connected to it, the client is disconnected and no longer receives notifications from the database. As there are no reconnect attempts, the client remains disconnected. This is why users no longer receive card updates through the frontends socket.io client.

## After
![after](https://user-images.githubusercontent.com/45343541/104092245-040e9980-52c6-11eb-9fe4-eddb8afe2952.gif)

This is what it looks like with the reconnect logic in place. The initial Postgres client instance becomes unusable when disconnected from Postgres, but immediately begins attempting reconnects. Once the database server is available and the reconnect is complete, the user will once again receive card updates through their socket.io stream.

## Reconnects
The following code snippets show a `pg.Pool` automatically reconnecting after a disconnect and a `pg.Client` not automatically reconnecting. Just run these scripts and restart Postgres with something like `balena stop postgres_3_1; sleep 2; balena start postgres_3_1` to check for yourself:

### `pg.Pool`
```
const pgp = require('pg-promise')()
const Bluebird = require('bluebird')

const main = async () => {
	const connection = pgp({
		host: 'postgres.ly.fish.local',
		user: 'docker',
		password: 'docker',
		database: 'jellyfish',
		port: 5432
	})

	while (true) {
		try {
			const record = await connection.one('SELECT id FROM cards LIMIT 1')
			console.log('Record:', record)
			await Bluebird.delay(1000)
		} catch (error) {
			console.log('Failed:', error.message)
		}
	}
}

main()
```

### `pg.Client`
```
const pgp = require('pg-promise')()
const Bluebird = require('bluebird')

const main = async () => {
	const connection = pgp({
		host: 'postgres.ly.fish.local',
		user: 'docker',
		password: 'docker',
		database: 'jellyfish',
		port: 5432
	})
	const client = await connection.connect()

	while (true) {
		try {
			const record = await client.one('SELECT id FROM cards LIMIT 1')
			console.log('Record:', record)
			await Bluebird.delay(1000)
		} catch (error) {
			console.log('Failed:', error.message)
		}
	}
}

main()
```

## ToDo
- [x] Update tests.
- [x] Add client reconnect test.
- [x] Add logs in `connection.$pool.on('error')` and `streamClient.connection.client.on('error')` event handlers. These could provide insight to a number of other problems we may be experiencing.
- [x] Add jsdoc.