### PR TITLE
Capture metrics for card patches

### DIFF
--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -14,6 +14,7 @@ const views = require('./views')
 const CARDS = require('./cards')
 const permissionFilter = require('./permission-filter')
 const logger = require('@balena/jellyfish-logger').getLogger(__filename)
+const metrics = require('@balena/jellyfish-metrics')
 
 const flattenSelected = (selected) => {
 	const flat = selected.properties
@@ -507,82 +508,85 @@ module.exports = class Kernel {
    * @returns {Object} the patched card
    */
 	async patchCardBySlug (context, session, slug, patch) {
-		const fullCard = await this.backend.getElementBySlug(
-			context, slug)
+		const result = await metrics.measureCardPatch(async () => {
+			const fullCard = await this.backend.getElementBySlug(
+				context, slug)
 
-		assert.INTERNAL(context, fullCard,
-			this.errors.JellyfishNoElement,
-			`No such card: ${slug}`)
+			assert.INTERNAL(context, fullCard,
+				this.errors.JellyfishNoElement,
+				`No such card: ${slug}`)
 
-		// Fetch necessary objects concurrently
-		const [
-			filteredCard,
-			typeCard,
-			filter
-		] = await Promise.all([
-			this.getCardBySlug(
-				context, session, `${fullCard.slug}@${fullCard.version}`),
-			this.getCardBySlug(context, session, fullCard.type),
-			permissionFilter.getMask(context, this.backend, session)
-		])
+			// Fetch necessary objects concurrently
+			const [
+				filteredCard,
+				typeCard,
+				filter
+			] = await Promise.all([
+				this.getCardBySlug(
+					context, session, `${fullCard.slug}@${fullCard.version}`),
+				this.getCardBySlug(context, session, fullCard.type),
+				permissionFilter.getMask(context, this.backend, session)
+			])
 
-		if (patch.length === 0) {
-			return filteredCard
-		}
-
-		assert.INTERNAL(context, filteredCard,
-			this.errors.JellyfishNoElement,
-			`No such card: ${slug}`)
-
-		const schema = typeCard && typeCard.data && typeCard.data.schema
-		assert.INTERNAL(context, schema,
-			this.errors.JellyfishUnknownCardType,
-			`Unknown type: ${fullCard.type}`)
-
-		/*
-		 * The idea of this algorithm is that we get the full card
-		 * as stored in the database and the card as the current actor
-		 * can see it. Then we apply the patch to both the full and
-		 * the filtered card, aborting if it fails on any. If it succeeds
-		 * then we upsert the full card to the database, but only
-		 * if the resulting filtered card still matches the permissions
-		 * filter.
-		 */
-
-		const patchedFilteredCard = patchCard(filteredCard, patch, {
-			mutate: true
-		})
-
-		jsonSchema.validate(filter, patchedFilteredCard)
-		const patchedFullCard = patchCard(fullCard, patch, {
-			mutate: false
-		})
-
-		try {
-			jsonSchema.validate(schema, patchedFullCard)
-		} catch (error) {
-			if (error instanceof errors.JellyfishSchemaMismatch) {
-				error.expected = true
-
-				// Because the "full" unrestricted card is being validated there is
-				// potential for an error message to leak private data. To prevent this,
-				// override the detailed error message with a generic one.
-				error.message = 'The updated card is invalid'
+			if (patch.length === 0) {
+				return filteredCard
 			}
 
-			throw error
-		}
+			assert.INTERNAL(context, filteredCard,
+				this.errors.JellyfishNoElement,
+				`No such card: ${slug}`)
 
-		// Don't do a pointless update
-		if (fastEquals.deepEqual(patchedFullCard, fullCard)) {
-			return fullCard
-		}
+			const schema = typeCard && typeCard.data && typeCard.data.schema
+			assert.INTERNAL(context, schema,
+				this.errors.JellyfishUnknownCardType,
+				`Unknown type: ${fullCard.type}`)
 
-		await this.backend.upsertElement(context, patchedFullCard)
+			/*
+			 * The idea of this algorithm is that we get the full card
+			 * as stored in the database and the card as the current actor
+			 * can see it. Then we apply the patch to both the full and
+			 * the filtered card, aborting if it fails on any. If it succeeds
+			 * then we upsert the full card to the database, but only
+			 * if the resulting filtered card still matches the permissions
+			 * filter.
+			 */
 
-		// Otherwise a person that patches a card gets
-		// to see the full card
-		return patchedFilteredCard
+			const patchedFilteredCard = patchCard(filteredCard, patch, {
+				mutate: true
+			})
+
+			jsonSchema.validate(filter, patchedFilteredCard)
+			const patchedFullCard = patchCard(fullCard, patch, {
+				mutate: false
+			})
+
+			try {
+				jsonSchema.validate(schema, patchedFullCard)
+			} catch (error) {
+				if (error instanceof errors.JellyfishSchemaMismatch) {
+					error.expected = true
+
+					// Because the "full" unrestricted card is being validated there is
+					// potential for an error message to leak private data. To prevent this,
+					// override the detailed error message with a generic one.
+					error.message = 'The updated card is invalid'
+				}
+
+				throw error
+			}
+
+			// Don't do a pointless update
+			if (fastEquals.deepEqual(patchedFullCard, fullCard)) {
+				return fullCard
+			}
+
+			await this.backend.upsertElement(context, patchedFullCard)
+
+			// Otherwise a person that patches a card gets
+			// to see the full card
+			return patchedFilteredCard
+		})
+		return result
 	}
 
 	/**


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Wrap card patch logic in metrics call that gathers:
- card patch request count
- card patch failure count
- card patch duration times

Did some final checking that the metrics are being properly gathered and exposed for Prometheus:
```
root@17ec8302b013:/usr/src/jellyfish/apps/action-server# curl -s http://monitor:TEST@localhost:9000/metrics | grep patch
# HELP jf_card_patch_total number of card patch requests
# TYPE jf_card_patch_total counter
jf_card_patch_total 6
# HELP jf_card_patch_duration_seconds histogram of durations taken to patch cards in seconds
# TYPE jf_card_patch_duration_seconds histogram
jf_card_patch_duration_seconds_bucket{le="0.004",type="support-thread"} 0
jf_card_patch_duration_seconds_bucket{le="0.0057",type="support-thread"} 0
jf_card_patch_duration_seconds_bucket{le="0.008",type="support-thread"} 1
jf_card_patch_duration_seconds_bucket{le="0.0113",type="support-thread"} 4
jf_card_patch_duration_seconds_bucket{le="0.016",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="0.0226",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="0.032",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="0.0453",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="0.064",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="0.0905",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="0.128",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="0.181",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="0.256",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="0.362",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="0.512",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="0.7241",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="1.024",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="1.4482",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="2.048",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="2.8963",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="4.096",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="5.7926",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="8.192",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="11.5852",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="16.384",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="23.1705",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="32.768",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="46.341",type="support-thread"} 6
jf_card_patch_duration_seconds_bucket{le="+Inf",type="support-thread"} 6
jf_card_patch_duration_seconds_sum{type="support-thread"} 0.066
jf_card_patch_duration_seconds_count{type="support-thread"} 6
```