### PR TITLE
Add default for UI schema snippet view mode

### DIFF
--- a/lib/cards/mixins/with-ui-schema.js
+++ b/lib/cards/mixins/with-ui-schema.js
@@ -11,7 +11,11 @@ const uiSchemaDefs = require('./ui-schema-defs.json')
 module.exports = {
 	data: {
 		uiSchema: {
-			fields: uiSchemaDefs.reset
+			fields: uiSchemaDefs.reset,
+			snippet: {
+				...uiSchemaDefs.reset,
+				data: null
+			}
 		}
 	}
 }


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

The default snippet UI schema 'view mode' is basically empty.

In the future, this view mode will be used by the `SingleCard` snippet lens.

_(In due course we should probably extend the Rendition `Renderer` component to support specifying an `only` property which prevents it displaying all fields by default)_
