### PR TITLE
Add logs on link card patches

### DIFF
--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -527,6 +527,14 @@ module.exports = class Kernel {
 					this.errors.JellyfishNoElement,
 					`No such card: ${slug}`)
 
+				// TODO: Remove this log once we understand why we are having link card patch requests.
+				if (fullCard.type === 'link@1.0.0') {
+					logger.info(context, 'Received request to patch a link card', {
+						card: fullCard,
+						patch
+					})
+				}
+
 				const filteredCard = await this.getCardBySlug(context, session, `${fullCard.slug}@${fullCard.version}`, options)
 				if (patch.length === 0) {
 					return filteredCard
@@ -579,6 +587,14 @@ module.exports = class Kernel {
 				// Don't do a pointless update
 				if (fastEquals.deepEqual(patchedFullCard, fullCard)) {
 					return fullCard
+				}
+
+				// TODO: Remove this log once we understand why we are having link card patch requests.
+				if (fullCard.type === 'link@1.0.0') {
+					logger.info(context, 'Upserting link card after patch', {
+						card: patchedFullCard,
+						patch
+					})
 				}
 
 				await this.backend.upsertElement(context, patchedFullCard, options)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

We've noticed in metrics that `link` card patch requests are coming in. Adding logs to try to explain why this is happening as it is unexpected and probably incorrect.