### PR TITLE
Fix schema for user's email field

### DIFF
--- a/lib/cards/user.js
+++ b/lib/cards/user.js
@@ -86,14 +86,23 @@ module.exports = {
 							]
 						},
 						email: {
-							type: [ 'string', 'array' ],
-							format: 'email',
-							uniqueItems: true,
-							minItems: 1,
-							items: {
-								type: 'string',
-								format: 'email'
-							}
+							oneOf: [
+								{
+									title: 'List of email addresses',
+									type: 'array',
+									uniqueItems: true,
+									minItems: 1,
+									items: {
+										type: 'string',
+										format: 'email'
+									}
+								},
+								{
+									title: 'Single email address',
+									type: 'string',
+									format: 'email'
+								}
+							]
 						},
 						hash: {
 							type: 'string',


### PR DESCRIPTION
react-jsonschema-form only supports arrays of types if one of them is `null`. So we should restructure how we define the `email` field so that it can be edited in the form in CreateLens/EditLens!

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Before:
![email field - before](https://user-images.githubusercontent.com/2925657/105330351-c2a2b600-5c04-11eb-9047-6c2fde409a5a.png)

After:
![email field - after](https://user-images.githubusercontent.com/2925657/105330212-9f780680-5c04-11eb-87c3-f696970486b7.png)
