### PR TITLE
Use `ui:explicit` in base snippet view mode

### DIFF
--- a/lib/cards/mixins/with-ui-schema.js
+++ b/lib/cards/mixins/with-ui-schema.js
@@ -13,8 +13,11 @@ module.exports = {
 		uiSchema: {
 			fields: uiSchemaDefs.reset,
 			snippet: {
-				...uiSchemaDefs.reset,
-				data: null
+				'ui:explicit': true,
+				data: {
+					'ui:title': null,
+					'ui:explicit': true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
By default, the snippet view mode should not render anything. Fields that are required must be explicitly referenced in the UI schema.

Note - the JF app currently doesn't use the snippet view mode so this change is safe to make.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>