### PR TITLE
Add ability to set session scope

### DIFF
--- a/lib/permission-filter.js
+++ b/lib/permission-filter.js
@@ -152,7 +152,9 @@ exports.unsafeUpsertCard = async (context, backend, card) => {
  * @param {Object} context - execution context
  * @param {Object} backend - backend
  * @param {String} session - session id
- * @returns {Object} actor card
+ * @returns {Object} sessionActor - actor card and session scope
+ * @returns {Object} sessionActor.actor - the actor card
+ * @returns {Object} sessionActor.scope - the session scope
  */
 exports.getSessionActor = async (context, backend, session) => {
 	const sessionCard = await backend.getElementById(context, session)
@@ -172,7 +174,10 @@ exports.getSessionActor = async (context, backend, session) => {
 	assert.INTERNAL(context, actor, errors.JellyfishNoElement,
 		`Invalid actor: ${sessionCard.data.actor}`)
 
-	return actor
+	return {
+		actor,
+		scope: sessionCard.data.scope || {}
+	}
 }
 
 /**
@@ -237,9 +242,9 @@ const evalSchema = (object, context) => {
 	return object
 }
 
-const getActorMask = async (context, backend, actor) => {
+const getActorMask = async (context, backend, actor, scope = {}) => {
 	const permissionFilters = await getRoleViews(context, backend, actor)
-	return applyMarkers(context, backend, actor, {
+	let mask = applyMarkers(context, backend, actor, {
 		type: 'object',
 
 		// At least one permission must match
@@ -251,6 +256,16 @@ const getActorMask = async (context, backend, actor) => {
 			})
 		})
 	})
+
+	// Apply session scope to mask
+	if (!_.isEmpty(scope)) {
+		mask = jsonSchema.merge([
+			mask,
+			scope
+		])
+	}
+
+	return mask
 }
 
 /**
@@ -264,8 +279,11 @@ const getActorMask = async (context, backend, actor) => {
  * @returns {Object} mask
  */
 exports.getMask = async (context, backend, session) => {
-	return getActorMask(context, backend,
-		await exports.getSessionActor(context, backend, session))
+	const {
+		actor,
+		scope
+	} = await exports.getSessionActor(context, backend, session)
+	return getActorMask(context, backend, actor, scope)
 }
 
 const mergeMaskInLinks = (schema, mask) => {
@@ -312,8 +330,11 @@ const mergeMaskInLinks = (schema, mask) => {
  * @returns {Object} query
  */
 exports.getQuery = async (context, backend, session, schema) => {
-	const actor = await exports.getSessionActor(context, backend, session)
-	const mask = await getActorMask(context, backend, actor)
+	const {
+		actor,
+		scope
+	} = await exports.getSessionActor(context, backend, session)
+	const mask = await getActorMask(context, backend, actor, scope)
 
 	// Apply permission mask to links, recursively
 	mergeMaskInLinks(schema, mask)


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

---

Necessary for: https://github.com/product-os/jellyfish-action-library/pull/428

- `jellyfish-plugin-default` [test pr](https://github.com/product-os/jellyfish-plugin-default/pull/136): [passed](https://ci.balena-dev.com/builds/738663)
- `jellyfish` [test pr](https://github.com/product-os/jellyfish/pull/5654): [passed](https://ci.balena-dev.com/builds/743181)

Add the ability to set scope for a session during creation. The scope definition itself is a JSON schema:
```
{
	"card": "user-jellyfish",
	"type": "user",
	"action": "action-create-session@1.0.0",
	"arguments": {
		"password": "jellyfish",
		"scope": {
			"type": "object",
			"properties": {
				"type": {
					"anyOf": [
						{
							"type": "string",
							"const": "message@1.0.0"
						}
					]
				}
			}
		}
	}
}
```
The above would grant access to `message@1.0.0` cards on behalf of the `user-jellyfish` user. 

## Test
Tested using the following query. The system has a single support thread with a single message linked to it, both accessible to the user for which the sessions are created.
```
{
   "query": {
      "type":"object",
      "properties":{
         "type":{
            "anyOf": [
               {
                  "type":"string",
                  "const":"message@1.0.0"
               },
               {
                  "type":"string",
                  "const":"support-thread@1.0.0"
               }
            ]
         }
      },
      "required":[
         "type"
      ]
   },
   "options": {}
}
```

Query results with a normal, non-scoped session includes both `support-thread@1.0.0` and `message@1.0.0` cards:
```
{
  "error": false,
  "data": [
    {
      "id": "a4c353fe-7979-403a-8acd-20e71c237d52",
      "data": {
        "status": "open",
        "product": "balenaCloud",
        "category": "general",
        "description": "asdf",
        "participants": [
          "e0102d56-3275-4483-b256-b476221873ef"
        ]
      },
      "name": "asdf-1",
      "slug": "support-thread-asdf-c95ec59c-a7d2-4f8e-a0ce-99bfe930c1af",
      "tags": [],
      "type": "support-thread@1.0.0",
      "links": {},
      "active": true,
      "markers": [
        "org-balena"
      ],
      "version": "1.0.0",
      "requires": [],
      "linked_at": {
        "has attached element": "2021-01-25T02:26:19.522Z"
      },
      "created_at": "2021-01-25T01:56:13.249Z",
      "updated_at": "2021-01-25T01:56:13.610Z",
      "capabilities": []
    },
    {
      "id": "41acc5b7-f6e9-4cfe-95ab-f8a16690eb83",
      "data": {
        "actor": "e0102d56-3275-4483-b256-b476221873ef",
        "target": "a4c353fe-7979-403a-8acd-20e71c237d52",
        "payload": {
          "message": "test message",
          "alertsUser": [],
          "alertsGroup": [],
          "mentionsUser": [],
          "mentionsGroup": []
        },
        "timestamp": "2021-01-25T02:26:19.346Z"
      },
      "name": null,
      "slug": "message-61a4ee77-7c35-46b3-9bdf-237723734f7e",
      "tags": [],
      "type": "message@1.0.0",
      "links": {},
      "active": true,
      "markers": [
        "org-balena"
      ],
      "version": "1.0.0",
      "requires": [],
      "linked_at": {
        "is attached to": "2021-01-25T02:26:19.522Z"
      },
      "created_at": "2021-01-25T02:26:19.402Z",
      "updated_at": null,
      "capabilities": []
    }
  ]
}
```

Query results with a `message@1.0.0`-only scoped session only include `message@1.0.0` cards:
```
{
  "error": false,
  "data": [
    {
      "id": "41acc5b7-f6e9-4cfe-95ab-f8a16690eb83",
      "data": {
        "actor": "e0102d56-3275-4483-b256-b476221873ef",
        "target": "a4c353fe-7979-403a-8acd-20e71c237d52",
        "payload": {
          "message": "test message",
          "alertsUser": [],
          "alertsGroup": [],
          "mentionsUser": [],
          "mentionsGroup": []
        },
        "timestamp": "2021-01-25T02:26:19.346Z"
      },
      "name": null,
      "slug": "message-61a4ee77-7c35-46b3-9bdf-237723734f7e",
      "tags": [],
      "type": "message@1.0.0",
      "links": {},
      "active": true,
      "markers": [
        "org-balena"
      ],
      "version": "1.0.0",
      "requires": [],
      "linked_at": {
        "is attached to": "2021-01-25T02:26:19.522Z"
      },
      "created_at": "2021-01-25T02:26:19.402Z",
      "updated_at": null,
      "capabilities": []
    }
  ]
}
```