### PR TITLE
Create indexes concurrently

### DIFF
--- a/lib/backend/postgres/cards.js
+++ b/lib/backend/postgres/cards.js
@@ -178,11 +178,11 @@ exports.setup = async (context, connection, database, options = {}) => {
 				})
 
 				await connection.any(`
-					CREATE INDEX IF NOT EXISTS ${fullyQualifiedIndexName} ON ${table}
+					CREATE INDEX CONCURRENTLY IF NOT EXISTS ${fullyQualifiedIndexName} ON ${table}
 					USING ${secondaryIndex.indexType || 'BTREE'} (${secondaryIndex.column} ${secondaryIndex.options || ''})`)
 			},
 			{
-				concurrency: 4
+				concurrency: 1
 			}
 		),
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

This PR is a precursor to the date column migration work. We will need to create indexes for the `new_created_at` and `new_updated_at` timestamp columns before beginning the actual migration and this PR will make that possible.

Create indexes concurrently so as to not block writes on the table, but execute each `CREATE INDEX` statement one at a time to avoid deadlock. Leaving Bluebird.map's concurrency at 4 resulted in following deadlock errors in my devenv, which makes sense according to the [docs](https://www.postgresql.org/docs/12/sql-createindex.html): "Regular index builds permit other regular index builds on the same table to occur simultaneously, but only one concurrent index build can occur on a table at a time.". Reducing the map concurrency to 1, results in no errors with all indexes being created.

```
[Logs]    [2/4/2021, 12:14:33 PM] [api] 2021-02-04T03:14:33.021Z [lib/bootstrap] [info] [SERVER-33.51.4-localhost-04f02904-2ff8-4dae-a493-d37843a754ab]: Instantiating core library
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 2021-02-04 03:14:33.710 UTC [392] ERROR:  deadlock detected
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 2021-02-04 03:14:33.710 UTC [392] DETAIL:  Process 392 waits for ShareUpdateExclusiveLock on relation 16387 of database 16386; blocked by process 393.
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 	Process 393 waits for ShareLock on virtual transaction 5/367; blocked by process 392.
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 	Process 392: 
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 						CREATE INDEX CONCURRENTLY IF NOT EXISTS new_updated_at_cards_idx ON cards
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 						USING BTREE (new_updated_at )
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 	Process 393: 
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 						CREATE INDEX CONCURRENTLY IF NOT EXISTS new_created_at_cards_idx ON cards
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 						USING BTREE (new_created_at DESC)
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 2021-02-04 03:14:33.710 UTC [392] HINT:  See server log for query details.
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 2021-02-04 03:14:33.710 UTC [392] STATEMENT:  
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 						CREATE INDEX CONCURRENTLY IF NOT EXISTS new_updated_at_cards_idx ON cards
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 						USING BTREE (new_updated_at )
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 2021-02-04 03:14:33.798 UTC [401] ERROR:  deadlock detected
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 2021-02-04 03:14:33.798 UTC [401] DETAIL:  Process 401 waits for ShareUpdateExclusiveLock on relation 16387 of database 16386; blocked by process 397.
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 	Process 397 waits for ShareLock on virtual transaction 12/451; blocked by process 401.
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 	Process 401: 
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 						CREATE INDEX CONCURRENTLY IF NOT EXISTS new_updated_at_cards_idx ON cards
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 	Process 397: 
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 						CREATE INDEX CONCURRENTLY IF NOT EXISTS new_updated_at_cards_idx ON cards
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 						USING BTREE (new_updated_at )
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 2021-02-04 03:14:33.798 UTC [401] HINT:  See server log for query details.
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 2021-02-04 03:14:33.798 UTC [401] STATEMENT:  
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 						CREATE INDEX CONCURRENTLY IF NOT EXISTS new_updated_at_cards_idx ON cards
[Logs]    [2/4/2021, 12:14:33 PM] [postgres] 						USING BTREE (new_updated_at )
[Logs]    [2/4/2021, 12:14:34 PM] [postgres] 2021-02-04 03:14:34.045 UTC [405] ERROR:  deadlock detected
[Logs]    [2/4/2021, 12:14:34 PM] [postgres] 2021-02-04 03:14:34.045 UTC [405] DETAIL:  Process 405 waits for ShareUpdateExclusiveLock on relation 16387 of database 16386; blocked by process 397.
[Logs]    [2/4/2021, 12:14:34 PM] [postgres] 	Process 397 waits for ShareLock on virtual transaction 15/348; blocked by process 405.
[Logs]    [2/4/2021, 12:14:34 PM] [postgres] 	Process 405: 
[Logs]    [2/4/2021, 12:14:34 PM] [postgres] 						CREATE INDEX CONCURRENTLY IF NOT EXISTS new_updated_at_cards_idx ON cards
[Logs]    [2/4/2021, 12:14:34 PM] [postgres] 						USING BTREE (new_updated_at )
[Logs]    [2/4/2021, 12:14:33 PM] [tick] 2021-02-04T03:14:33.713Z [lib/tick] [crit] [TICK-33.51.4-31c25c9e-afc6-4793-a9c8-339a2a2cee6f]: Tick worker error {"name":"error","message":"deadlock detected","stack":"error: deadlock detected\n    at Parser.parseErrorMessage (/usr/src/jellyfish/apps/action-server/node_modules/pg-protocol/dist/parser.js:278:15)\n    at Parser.handlePacket (/usr/src/jellyfish/apps/action-server/node_modules/pg-protocol/dist/parser.js:126:29)\n    at Parser.parse (/usr/src/jellyfish/apps/action-server/node_modules/pg-protocol/dist/parser.js:39:38)\n    at Socket.<anonymous> (/usr/src/jellyfish/apps/action-server/node_modules/pg-protocol/dist/index.js:10:42)\n    at Socket.emit (events.js:315:20)\n    at Socket.EventEmitter.emit (domain.js:467:12)\n    at addChunk (internal/streams/readable.js:309:12)\n    at readableAddChunk (internal/streams/readable.js:284:9)\n    at Socket.Readable.push (internal/streams/readable.js:223:10)\n    at TCP.onStreamRead (internal/stream_base_commons.js:188:23)","length":309,"severity":"ERROR","code":"40P01","detail":"Process 392 waits for ShareUpdateExclusiveLock on relation 16387 of database 16386; blocked by process 393.\nProcess 393 waits for ShareLock on virtual transaction 5/367; blocked by process 392.","hint":"See server log for query details.","file":"deadlock.c","line":"1146","routine":"DeadLockReport"}
[Logs]    [2/4/2021, 12:14:33 PM] [worker_2] 2021-02-04T03:14:33.804Z [lib/worker] [crit] [WORKER-33.51.4-f8e8b07b-9829-4980-b9a0-b51121f12f6a]: Worker error {"name":"error","message":"deadlock detected","stack":"error: deadlock detected\n    at Parser.parseErrorMessage (/usr/src/jellyfish/apps/action-server/node_modules/pg-protocol/dist/parser.js:278:15)\n    at Parser.handlePacket (/usr/src/jellyfish/apps/action-server/node_modules/pg-protocol/dist/parser.js:126:29)\n    at Parser.parse (/usr/src/jellyfish/apps/action-server/node_modules/pg-protocol/dist/parser.js:39:38)\n    at Socket.<anonymous> (/usr/src/jellyfish/apps/action-server/node_modules/pg-protocol/dist/index.js:10:42)\n    at Socket.emit (events.js:315:20)\n    at Socket.EventEmitter.emit (domain.js:467:12)\n    at addChunk (internal/streams/readable.js:309:12)\n    at readableAddChunk (internal/streams/readable.js:284:9)\n    at Socket.Readable.push (internal/streams/readable.js:223:10)\n    at TCP.onStreamRead (internal/stream_base_commons.js:188:23)","length":310,"severity":"ERROR","code":"40P01","detail":"Process 401 waits for ShareUpdateExclusiveLock on relation 16387 of database 16386; blocked by process 397.\nProcess 397 waits for ShareLock on virtual transaction 12/451; blocked by process 401.","hint":"See server log for query details.","file":"deadlock.c","line":"1146","routine":"DeadLockReport"}
[Logs]    [2/4/2021, 12:14:34 PM] [postgres] 	Process 397: 
[Logs]    [2/4/2021, 12:14:34 PM] [postgres] 						CREATE INDEX CONCURRENTLY IF NOT EXISTS new_updated_at_cards_idx ON cards
[Logs]    [2/4/2021, 12:14:34 PM] [postgres] 						USING BTREE (new_updated_at )
[Logs]    [2/4/2021, 12:14:34 PM] [postgres] 2021-02-04 03:14:34.045 UTC [405] HINT:  See server log for query details.
[Logs]    [2/4/2021, 12:14:34 PM] [postgres] 2021-02-04 03:14:34.045 UTC [405] STATEMENT:  
[Logs]    [2/4/2021, 12:14:34 PM] [postgres] 						CREATE INDEX CONCURRENTLY IF NOT EXISTS new_updated_at_cards_idx ON cards
[Logs]    [2/4/2021, 12:14:34 PM] [postgres] 						USING BTREE (new_updated_at )
```