### PR TITLE
Create index for new_updated_at timestamp column

### DIFF
--- a/lib/backend/postgres/cards.js
+++ b/lib/backend/postgres/cards.js
@@ -151,6 +151,9 @@ exports.setup = async (context, connection, database, options = {}) => {
 				},
 				{
 					column: 'updated_at'
+				},
+				{
+					column: 'new_updated_at'
 				}
 			],
 			async (secondaryIndex) => {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Creating an index for the `new_updated_at` timestamp column. This is a precursor to the date column migration work. The index for `new_created_at` timestamp column will be created in a separate PR in order to space out the creation of multiple indexes for tens of millions of cards.