### PR TITLE
Create index for new_created_at timestamp column

### DIFF
--- a/lib/backend/postgres/cards.js
+++ b/lib/backend/postgres/cards.js
@@ -153,6 +153,10 @@ exports.setup = async (context, connection, database, options = {}) => {
 					column: 'updated_at'
 				},
 				{
+					column: 'new_created_at',
+					options: 'DESC'
+				},
+				{
 					column: 'new_updated_at'
 				}
 			],


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Creates an index for the `new_created_at` timestamp column. This is a precursor to the date column migration work.

Depends on https://github.com/product-os/jellyfish-core/pull/409, waiting for it to be released to production before merging this.