### PR TITLE
Retry index creation on deadlock error

### DIFF
--- a/lib/backend/postgres/cards.js
+++ b/lib/backend/postgres/cards.js
@@ -60,6 +60,9 @@ exports.INIT_LOCK = 1142043989439426
 exports.TABLE = CARDS_TABLE
 exports.TRIGGER_COLUMNS = CARDS_TRIGGER_COLUMNS
 
+// Postgres error codes
+const DEADLOCK_ERROR_CODE = '40P01'
+
 exports.setup = async (context, connection, database, options = {}) => {
 	const table = options.table || exports.TABLE
 
@@ -184,9 +187,8 @@ exports.setup = async (context, connection, database, options = {}) => {
 					index: secondaryIndex.column
 				})
 
-				await connection.any(`
-					CREATE INDEX CONCURRENTLY IF NOT EXISTS ${fullyQualifiedIndexName} ON ${table}
-					USING ${secondaryIndex.indexType || 'BTREE'} (${secondaryIndex.column} ${secondaryIndex.options || ''})`)
+				await exports.createIndexConcurrently(context, connection, table, fullyQualifiedIndexName,
+					`USING ${secondaryIndex.indexType || 'BTREE'} (${secondaryIndex.column} ${secondaryIndex.options || ''})`)
 			},
 			{
 				concurrency: 1
@@ -572,12 +574,8 @@ exports.createTypeIndex = async (context, connection, fields, type) => {
 
 	const versionedType = type.includes('@') ? type : `${type}@1.0.0`
 
-	// Statement timeout is set to 0 to prevent large index creations from timing out
-	await connection.task(async (task) => {
-		await task.any('SET statement_timeout=0')
-		await task.any(`CREATE INDEX CONCURRENTLY IF NOT EXISTS "${fullyQualifiedIndexName}" ON ${CARDS_TABLE}
-		(${columns.join(',')}) WHERE type=${pgFormat.literal(versionedType)}`)
-	})
+	await exports.createIndexConcurrently(context, connection, CARDS_TABLE, fullyQualifiedIndexName,
+		`(${columns.join(',')}) WHERE type=${pgFormat.literal(versionedType)}`)
 }
 
 /**
@@ -696,4 +694,42 @@ exports.fromTypePath = (from) => {
 	})
 	path.push(target)
 	return path
+}
+
+/**
+ * Create an index concurrently.
+ * Retry on deadlock, which commonly occurs when multiple services attempt to initialize the backend at the same time.
+ * Postgres does not allow multiple "CREATE INDEX CONCURRENTLY" executions for the same table at the same time.
+ *
+ * @function
+ *
+ * @param {Object} context - execution context
+ * @param {Object} connection - connection to database
+ * @param {Object} tableName - table name
+ * @param {String} indexName - index name
+ * @param {String} predicate - index create statement predicate
+ *
+ * @example
+ * await exports.createIndexConcurrently(context, connection, 'cards', 'example_idx', 'USING btree (updated_at)')
+ */
+exports.createIndexConcurrently = async (context, connection, tableName, indexName, predicate) => {
+	const statement = `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${indexName}" ON ${tableName} ${predicate}`
+	try {
+		await connection.task(async (task) => {
+			await task.any('SET statement_timeout=0')
+			await task.any(statement)
+		})
+	} catch (error) {
+		if (error.code === DEADLOCK_ERROR_CODE) {
+			logger.debug(context, 'Deadlock encountered on index creation', {
+				table: tableName,
+				index: indexName,
+				statement
+			})
+			await Bluebird.delay(1000)
+			await exports.createIndexConcurrently(context, connection, tableName, indexName, predicate)
+		} else {
+			throw error
+		}
+	}
 }

--- a/test/integration/backend/postgres/cards.spec.js
+++ b/test/integration/backend/postgres/cards.spec.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const helpers = require('../helpers')
+const cards = require('../../../../lib/backend/postgres/cards')
+
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
+
+ava('.createIndexConcurrently() should create indexes', async (test) => {
+	const name = `${test.context.generateRandomSlug().replace(/-/g, '_')}_idx`
+	await cards.createIndexConcurrently(test.context.context, test.context.backend.connection, cards.TABLE, name,
+		'USING btree (updated_at)')
+
+	const index = await test.context.backend.connection.one(`SELECT EXISTS (SELECT FROM pg_indexes WHERE indexname='${name}')`)
+	test.truthy(index.exists)
+})


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Resolves https://github.com/product-os/jellyfish-core/issues/415

When deadlock errors are encountered on `CREATE INDEX CONCURRENTLY` executions, try again until the error no longer occurs. From what I've seen this occurs most often in CI when multiple services attempt to initialize the backend at the same time, which results multiple `CREATE INDEX CONCURRENTLY` statements being executed simultaneously on the same table - something Postgres does not allow.