### PR TITLE
Create fulltext search indexes concurrently

### DIFF
--- a/lib/backend/postgres/cards.js
+++ b/lib/backend/postgres/cards.js
@@ -603,28 +603,20 @@ exports.createFullTextSearchIndex = async (context, connection, type, fields) =>
 	// Create all necessary search indexes for the given type
 	const typeBase = type.split('@')[0]
 	const versionedType = `${typeBase}@1.0.0`
-	await connection.task(async (task) => {
-		const tasks = []
-		fields.forEach((field) => {
-			const path = SqlPath.fromArray(_.clone(field.path))
-			const isJson = path.isProcessingJsonProperty
-			const name = `${typeBase}__${field.path.join('_')}__search_idx`
-			tasks.push(task.any(`CREATE INDEX IF NOT EXISTS "${name}" ON ${CARDS_TABLE}
-				USING GIN(${textSearch.toTSVector(path.toSql(CARDS_TABLE), isJson, field.isArray)})
-				WHERE type=${pgFormat.literal(versionedType)}`))
+	for (const field of fields) {
+		const path = SqlPath.fromArray(_.clone(field.path))
+		const isJson = path.isProcessingJsonProperty
+		const name = `${typeBase}__${field.path.join('_')}__search_idx`
 
-			logger.info(context, 'Creating search index', {
-				typeBase,
-				name
-			})
+		logger.debug(context, 'Creating search index', {
+			typeBase,
+			name
 		})
 
-		// Prevent large index creation timeouts and then create all indexes
-		await task.any('SET statement_timeout=0')
-		await Bluebird.all(tasks).catch((error) => {
-			throw error
-		})
-	})
+		await exports.createIndexConcurrently(context, connection, CARDS_TABLE, name,
+			`USING GIN(${textSearch.toTSVector(path.toSql(CARDS_TABLE), isJson, field.isArray)})
+				WHERE type=${pgFormat.literal(versionedType)}`)
+	}
 }
 
 /* @summary Parse field paths denoted as being targets for full-text search


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Create fulltext search indexes `CONCURRENTLY` in the same way other indexes are created, using the shared function to handle deadlock errors if/when they occur.