### PR TITLE
Replace date column names

### DIFF
--- a/lib/backend/postgres/cards.js
+++ b/lib/backend/postgres/cards.js
@@ -86,15 +86,15 @@ exports.setup = async (context, connection, database, options = {}) => {
 				name TEXT,
 				tags TEXT[] NOT NULL,
 				markers TEXT[] NOT NULL,
-				created_at TEXT NOT NULL,
+				old_created_at TEXT NOT NULL,
 				links JSONB NOT NULL,
 				requires JSONB[] NOT NULL,
 				capabilities JSONB[] NOT NULL,
 				data JSONB NOT NULL,
-				updated_at TEXT,
+				old_updated_at TEXT,
 				linked_at JSONB NOT NULL,
-				new_created_at TIMESTAMP WITH TIME ZONE NOT NULL,
-				new_updated_at TIMESTAMP WITH TIME ZONE,
+				created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+				updated_at TIMESTAMP WITH TIME ZONE,
 				UNIQUE (slug, version_major, version_minor, version_patch),
 				CONSTRAINT version_positive
 					CHECK (version_major >= 0 AND version_minor >= 0 AND version_patch >= 0));
@@ -149,18 +149,18 @@ exports.setup = async (context, connection, database, options = {}) => {
 					options: 'jsonb_path_ops'
 				},
 				{
+					column: 'old_created_at',
+					options: 'DESC'
+				},
+				{
+					column: 'old_updated_at'
+				},
+				{
 					column: 'created_at',
 					options: 'DESC'
 				},
 				{
 					column: 'updated_at'
-				},
-				{
-					column: 'new_created_at',
-					options: 'DESC'
-				},
-				{
-					column: 'new_updated_at'
 				}
 			],
 			async (secondaryIndex) => {
@@ -375,7 +375,7 @@ exports.upsert = async (context, errors, connection, object, options) => {
 		insertedObject.requires,
 		insertedObject.capabilities,
 		insertedObject.data,
-		insertedObject.updated_at,
+		insertedObject.updated_at ? insertedObject.updated_at : null,
 		{},
 		new Date(insertedObject.created_at),
 		insertedObject.updated_at ? new Date(insertedObject.updated_at) : null
@@ -393,9 +393,9 @@ exports.upsert = async (context, errors, connection, object, options) => {
 				INSERT INTO ${table}
 					(id, slug, type, active,
 					version_major, version_minor, version_patch,
-					name, tags, markers, created_at, links, requires,
-					capabilities, data, updated_at,
-					linked_at, new_created_at, new_updated_at)
+					name, tags, markers, old_created_at, links, requires,
+					capabilities, data, old_updated_at,
+					linked_at, created_at, updated_at)
 				VALUES
 					($1, $2, $3, $4,
 					$5, $6, $7,
@@ -408,15 +408,15 @@ exports.upsert = async (context, errors, connection, object, options) => {
 					name = $8,
 					tags = $9,
 					markers = $10,
-					created_at = ${table}.created_at,
+					old_created_at = ${table}.old_created_at,
 					links = ${table}.links,
 					requires = $13,
 					capabilities = $14,
 					data = $15,
-					updated_at = $16,
+					old_updated_at = $16,
 					linked_at = ${table}.linked_at,
-					new_created_at = ${table}.new_created_at,
-					new_updated_at = $19
+					created_at = ${table}.created_at,
+					updated_at = $19
 				RETURNING ${CARDS_SELECT}`
 
 			results = await connection.any({
@@ -429,9 +429,9 @@ exports.upsert = async (context, errors, connection, object, options) => {
 				INSERT INTO ${table}
 					(id, slug, type, active,
 					version_major, version_minor, version_patch,
-					name, tags, markers, created_at, links, requires,
-					capabilities, data, updated_at,
-					linked_at, new_created_at, new_updated_at)
+					name, tags, markers, old_created_at, links, requires,
+					capabilities, data, old_updated_at,
+					linked_at, created_at, updated_at)
 				VALUES
 					($1, $2, $3, $4, $5, $6, $7, $8,
 					$9, $10, $11, $12, $13, $14,

--- a/lib/backend/postgres/utils.js
+++ b/lib/backend/postgres/utils.js
@@ -30,9 +30,9 @@ exports.convertDatesToISOString = (row) => {
 		row.updated_at = new Date(row.updated_at).toISOString()
 	}
 
-	// FIXME remove references to new_* columns
-	Reflect.deleteProperty(row, 'new_created_at')
-	Reflect.deleteProperty(row, 'new_updated_at')
+	// FIXME remove references to old_* columns
+	Reflect.deleteProperty(row, 'old_created_at')
+	Reflect.deleteProperty(row, 'old_updated_at')
 
 	return row
 }

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -139,8 +139,8 @@ const patchCard = (card, patch, options = {}) => {
 			operation.path.startsWith('/linked_at') ||
 			operation.path.startsWith('/created_at') ||
 			operation.path.startsWith('/updated_at') ||
-			operation.path.startsWith('/new_created_at') ||
-			operation.path.startsWith('/new_updated_at')) {
+			operation.path.startsWith('/old_created_at') ||
+			operation.path.startsWith('/old_updated_at')) {
 			return accumulator
 		}
 


### PR DESCRIPTION
Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>

---

Step 4 of date column migration work: https://github.com/product-os/jellyfish/issues/5519
SQL draft PR: https://github.com/product-os/jellyfish/pull/5603

Replace references to date column names to match new table definition post migration:
- `created_at` => `old_created_at`
- `updated_at` => `old_updated_at`
- `new_created_at` => `created_at`
- `new_updated_at` => `updated_at`

## Tests
- [jellyfish-plugin-default](https://github.com/product-os/jellyfish-plugin-default/pull/184): [PASS](https://ci.balena-dev.com/builds/762809)
- [jellyfish](https://github.com/product-os/jellyfish/pull/5718): [PASS](https://ci.balena-dev.com/builds/762791)