### PR TITLE
Stop creating indexes concurrently

### DIFF
--- a/lib/backend/postgres/cards.js
+++ b/lib/backend/postgres/cards.js
@@ -60,9 +60,6 @@ exports.INIT_LOCK = 1142043989439426
 exports.TABLE = CARDS_TABLE
 exports.TRIGGER_COLUMNS = CARDS_TRIGGER_COLUMNS
 
-// Postgres error codes
-const DEADLOCK_ERROR_CODE = '40P01'
-
 exports.setup = async (context, connection, database, options = {}) => {
 	const table = options.table || exports.TABLE
 
@@ -181,13 +178,7 @@ exports.setup = async (context, connection, database, options = {}) => {
 					return
 				}
 
-				logger.debug(context, 'Attempting to create table index', {
-					table,
-					database,
-					index: secondaryIndex.column
-				})
-
-				await exports.createIndexConcurrently(context, connection, table, fullyQualifiedIndexName,
+				await utils.createIndex(context, connection, table, fullyQualifiedIndexName,
 					`USING ${secondaryIndex.indexType || 'BTREE'} (${secondaryIndex.column} ${secondaryIndex.options || ''})`)
 			},
 			{
@@ -551,11 +542,6 @@ exports.createTypeIndex = async (context, connection, fields, type) => {
 		return
 	}
 
-	logger.debug(context, 'Attempting to create cards table type index', {
-		index: fields,
-		type
-	})
-
 	const columns = []
 	for (const path of fields) {
 		// Make the assumption that if the index is dot seperated, it is a json path
@@ -574,7 +560,7 @@ exports.createTypeIndex = async (context, connection, fields, type) => {
 
 	const versionedType = type.includes('@') ? type : `${type}@1.0.0`
 
-	await exports.createIndexConcurrently(context, connection, CARDS_TABLE, fullyQualifiedIndexName,
+	await utils.createIndex(context, connection, CARDS_TABLE, fullyQualifiedIndexName,
 		`(${columns.join(',')}) WHERE type=${pgFormat.literal(versionedType)}`)
 }
 
@@ -607,13 +593,7 @@ exports.createFullTextSearchIndex = async (context, connection, type, fields) =>
 		const path = SqlPath.fromArray(_.clone(field.path))
 		const isJson = path.isProcessingJsonProperty
 		const name = `${typeBase}__${field.path.join('_')}__search_idx`
-
-		logger.debug(context, 'Creating search index', {
-			typeBase,
-			name
-		})
-
-		await exports.createIndexConcurrently(context, connection, CARDS_TABLE, name,
+		await utils.createIndex(context, connection, CARDS_TABLE, name,
 			`USING GIN(${textSearch.toTSVector(path.toSql(CARDS_TABLE), isJson, field.isArray)})
 				WHERE type=${pgFormat.literal(versionedType)}`)
 	}
@@ -686,42 +666,4 @@ exports.fromTypePath = (from) => {
 	})
 	path.push(target)
 	return path
-}
-
-/**
- * Create an index concurrently.
- * Retry on deadlock, which commonly occurs when multiple services attempt to initialize the backend at the same time.
- * Postgres does not allow multiple "CREATE INDEX CONCURRENTLY" executions for the same table at the same time.
- *
- * @function
- *
- * @param {Object} context - execution context
- * @param {Object} connection - connection to database
- * @param {Object} tableName - table name
- * @param {String} indexName - index name
- * @param {String} predicate - index create statement predicate
- *
- * @example
- * await exports.createIndexConcurrently(context, connection, 'cards', 'example_idx', 'USING btree (updated_at)')
- */
-exports.createIndexConcurrently = async (context, connection, tableName, indexName, predicate) => {
-	const statement = `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${indexName}" ON ${tableName} ${predicate}`
-	try {
-		await connection.task(async (task) => {
-			await task.any('SET statement_timeout=0')
-			await task.any(statement)
-		})
-	} catch (error) {
-		if (error.code === DEADLOCK_ERROR_CODE) {
-			logger.debug(context, 'Deadlock encountered on index creation', {
-				table: tableName,
-				index: indexName,
-				statement
-			})
-			await Bluebird.delay(1000)
-			await exports.createIndexConcurrently(context, connection, tableName, indexName, predicate)
-		} else {
-			throw error
-		}
-	}
 }

--- a/lib/backend/postgres/links.js
+++ b/lib/backend/postgres/links.js
@@ -6,6 +6,7 @@
 
 const _ = require('lodash')
 const logger = require('@balena/jellyfish-logger').getLogger(__filename)
+const utils = require('./utils')
 
 const LINK_ORIGIN_PROPERTY = '$link'
 const LINK_TABLE = 'links'
@@ -61,11 +62,8 @@ exports.setup = async (context, connection, database, options) => {
 	const slugVersionIndex =
 		`${LINK_TABLE}_slug_version_major_version_minor_version_patch_key`
 	if (!indexes.includes(slugVersionIndex)) {
-		initTasks.push(connection.task(async (task) => {
-			await task.any('SET statement_timeout = 0')
-			await task.any(`CREATE UNIQUE INDEX CONCURRENTLY ${slugVersionIndex}
-				ON ${LINK_TABLE} USING btree (slug, version_major, version_minor, version_patch)`)
-		}))
+		await utils.createIndex(context, connection, LINK_TABLE, slugVersionIndex,
+			'USING btree (slug, version_major, version_minor, version_patch)', true)
 	}
 
 	for (const [ name, column ] of [
@@ -76,15 +74,7 @@ exports.setup = async (context, connection, database, options) => {
 			return
 		}
 
-		logger.debug(context, 'Attempting to create table index', {
-			table: LINK_TABLE,
-			database,
-			index: name
-		})
-
-		initTasks.push(connection.any(`
-			CREATE INDEX IF NOT EXISTS ${name} ON ${LINK_TABLE}
-			USING BTREE (${column})`))
+		await utils.createIndex(context, connection, LINK_TABLE, name, `USING BTREE (${column})`)
 	}
 
 	await Promise.all(initTasks)

--- a/lib/backend/postgres/utils.js
+++ b/lib/backend/postgres/utils.js
@@ -5,6 +5,7 @@
  */
 
 const _ = require('lodash')
+const logger = require('@balena/jellyfish-logger').getLogger(__filename)
 
 // List of Postgres error codes we can safely ignore during initial db setup.
 // All error codes: https://www.postgresql.org/docs/12/errcodes-appendix.html
@@ -85,4 +86,33 @@ exports.removeVersionFields = (row) => {
  */
 exports.isIgnorableInitError = (code) => {
 	return _.includes(INIT_IGNORE_CODES, code)
+}
+
+/**
+ * Create an index.
+ *
+ * @function
+ *
+ * @param {Object} context - execution context
+ * @param {Object} connection - connection to database
+ * @param {String} tableName - table name
+ * @param {String} indexName - index name
+ * @param {String} predicate - index create statement predicate
+ * @param {Boolean} unique - declare index as UNIQUE (optional)
+ *
+ * @example
+ * await exports.createIndex(context, connection, 'cards', 'example_idx', 'USING btree (updated_at)')
+ */
+exports.createIndex = async (context, connection, tableName, indexName, predicate, unique = false) => {
+	logger.debug(context, 'Attempting to create table index', {
+		table: tableName,
+		index: indexName
+	})
+
+	const uniqueFlag = (unique) ? 'UNIQUE' : ''
+	const statement = `CREATE ${uniqueFlag} INDEX IF NOT EXISTS "${indexName}" ON ${tableName} ${predicate}`
+	await connection.task(async (task) => {
+		await task.any('SET statement_timeout=0')
+		await task.any(statement)
+	})
 }

--- a/test/integration/backend/postgres/utils.spec.js
+++ b/test/integration/backend/postgres/utils.spec.js
@@ -7,14 +7,14 @@
 const ava = require('ava')
 const helpers = require('../helpers')
 const cards = require('../../../../lib/backend/postgres/cards')
+const utils = require('../../../../lib/backend/postgres/utils')
 
 ava.serial.before(helpers.before)
 ava.serial.after(helpers.after)
 
-ava('.createIndexConcurrently() should create indexes', async (test) => {
+ava('.createIndex() should create indexes', async (test) => {
 	const name = `${test.context.generateRandomSlug().replace(/-/g, '_')}_idx`
-	await cards.createIndexConcurrently(test.context.context, test.context.backend.connection, cards.TABLE, name,
-		'USING btree (updated_at)')
+	await utils.createIndex(test.context.context, test.context.backend.connection, cards.TABLE, name, 'USING btree (updated_at)')
 
 	const index = await test.context.backend.connection.one(`SELECT EXISTS (SELECT FROM pg_indexes WHERE indexname='${name}')`)
 	test.truthy(index.exists)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Found out today that even if we catch Postgres deadlock errors at the code level, Postgres gives up on creating the index when this error occurs, resulting in invalid and unused indexes. As we currently have multiple backend services attempting to create the same indexes `CONCURRENTLY` at the same time, we cannot currently ensure deadlocks will not occur unless we stop creating them `CONCURRENTLY`. A better solution to this problem is presented here: https://github.com/product-os/jellyfish/issues/5741

We have had this problem for [quite a while](https://github.com/product-os/jellyfish-core/blob/56126644a8af6d3a53397c198fb3a09879178846/lib/backend/postgres/cards.js#L571), but my [recent changes](https://github.com/product-os/jellyfish-core/pull/402) have made the issue more apparent.

Note: I have gone into the production database and rebuilt all invalid indexes manually.