### PR TITLE
Remove references to old TEXT date columns

### DIFF
--- a/lib/backend/postgres/cards.js
+++ b/lib/backend/postgres/cards.js
@@ -83,12 +83,10 @@ exports.setup = async (context, connection, database, options = {}) => {
 				name TEXT,
 				tags TEXT[] NOT NULL,
 				markers TEXT[] NOT NULL,
-				old_created_at TEXT NOT NULL,
 				links JSONB NOT NULL,
 				requires JSONB[] NOT NULL,
 				capabilities JSONB[] NOT NULL,
 				data JSONB NOT NULL,
-				old_updated_at TEXT,
 				linked_at JSONB NOT NULL,
 				created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 				updated_at TIMESTAMP WITH TIME ZONE,
@@ -144,13 +142,6 @@ exports.setup = async (context, connection, database, options = {}) => {
 					column: '(data->\'mirrors\')',
 					indexType: 'GIN',
 					options: 'jsonb_path_ops'
-				},
-				{
-					column: 'old_created_at',
-					options: 'DESC'
-				},
-				{
-					column: 'old_updated_at'
 				},
 				{
 					column: 'created_at',
@@ -361,12 +352,10 @@ exports.upsert = async (context, errors, connection, object, options) => {
 			: null,
 		insertedObject.tags,
 		insertedObject.markers,
-		insertedObject.created_at,
 		insertedObject.links,
 		insertedObject.requires,
 		insertedObject.capabilities,
 		insertedObject.data,
-		insertedObject.updated_at ? insertedObject.updated_at : null,
 		{},
 		new Date(insertedObject.created_at),
 		insertedObject.updated_at ? new Date(insertedObject.updated_at) : null
@@ -384,30 +373,26 @@ exports.upsert = async (context, errors, connection, object, options) => {
 				INSERT INTO ${table}
 					(id, slug, type, active,
 					version_major, version_minor, version_patch,
-					name, tags, markers, old_created_at, links, requires,
-					capabilities, data, old_updated_at,
-					linked_at, created_at, updated_at)
+					name, tags, markers, links, requires,
+					capabilities, data, linked_at, created_at, updated_at)
 				VALUES
 					($1, $2, $3, $4,
 					$5, $6, $7,
-					$8, $9, $10, $11, $12, $13,
-					$14, $15, NULL,
-					$17, $18, NULL)
+					$8, $9, $10, $11, $12,
+					$13, $14, $15, $16, NULL)
 				ON CONFLICT (slug, version_major, version_minor, version_patch) DO UPDATE SET
 					id = ${table}.id,
 					active = $4,
 					name = $8,
 					tags = $9,
 					markers = $10,
-					old_created_at = ${table}.old_created_at,
 					links = ${table}.links,
-					requires = $13,
-					capabilities = $14,
-					data = $15,
-					old_updated_at = $16,
+					requires = $12,
+					capabilities = $13,
+					data = $14,
 					linked_at = ${table}.linked_at,
 					created_at = ${table}.created_at,
-					updated_at = $19
+					updated_at = $17
 				RETURNING ${CARDS_SELECT}`
 
 			results = await connection.any({
@@ -420,13 +405,11 @@ exports.upsert = async (context, errors, connection, object, options) => {
 				INSERT INTO ${table}
 					(id, slug, type, active,
 					version_major, version_minor, version_patch,
-					name, tags, markers, old_created_at, links, requires,
-					capabilities, data, old_updated_at,
-					linked_at, created_at, updated_at)
+					name, tags, markers, links, requires,
+					capabilities, data, linked_at, created_at, updated_at)
 				VALUES
 					($1, $2, $3, $4, $5, $6, $7, $8,
-					$9, $10, $11, $12, $13, $14,
-					$15, $16, $17, $18, $19)
+					$9, $10, $11, $12, $13, $14, $15, $16, $17)
 				RETURNING ${CARDS_SELECT}`
 			results = await connection.any({
 				name: `cards-upsert-insert-${table}`,

--- a/lib/backend/postgres/utils.js
+++ b/lib/backend/postgres/utils.js
@@ -31,10 +31,6 @@ exports.convertDatesToISOString = (row) => {
 		row.updated_at = new Date(row.updated_at).toISOString()
 	}
 
-	// FIXME remove references to old_* columns
-	Reflect.deleteProperty(row, 'old_created_at')
-	Reflect.deleteProperty(row, 'old_updated_at')
-
 	return row
 }
 

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -133,14 +133,11 @@ const patchCard = (card, patch, options = {}) => {
 				`Patch operation has no path: ${JSON.stringify(operation, null, 2)}`)
 		}
 
-		// FIXME remove references to new_* columns
 		if (operation.path.startsWith('/id') ||
 			operation.path.startsWith('/links') ||
 			operation.path.startsWith('/linked_at') ||
 			operation.path.startsWith('/created_at') ||
-			operation.path.startsWith('/updated_at') ||
-			operation.path.startsWith('/old_created_at') ||
-			operation.path.startsWith('/old_updated_at')) {
+			operation.path.startsWith('/updated_at')) {
 			return accumulator
 		}
 


### PR DESCRIPTION
Remove references to old `TEXT`-typed date columns:
- `old_created_at`
- `old_updated_at`

Step 6 of the date column migration project: https://github.com/product-os/jellyfish/issues/5519
Once references are removed from the code base and we confirm that no problems arise, we can move to dropping the old columns alone with their indexes from the database (step 7).

## Tests
- [jellyfish](https://github.com/product-os/jellyfish/pull/5786): [PASS](https://ci.balena-dev.com/builds/783843)
- [jellyfish-plugin-default](https://github.com/product-os/jellyfish-plugin-default/pull/217): [PASS](https://ci.balena-dev.com/builds/778477)