### PR TITLE
Remove obsolete lenses field from view type schema

### DIFF
--- a/lib/cards/view.js
+++ b/lib/cards/view.js
@@ -98,12 +98,6 @@ module.exports = {
 							items: {
 								type: 'string'
 							}
-						},
-						lenses: {
-							type: 'array',
-							items: {
-								type: 'string'
-							}
 						}
 					}
 				}


### PR DESCRIPTION
The front-end now automatically works out which lenses to use for a view.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Once this is merged, I'll go ahead and remove the `lenses` fields in all the view cards in various plugins!