### PR TITLE
Temporarily remove version columns from trigger targets

### DIFF
--- a/lib/backend/postgres/cards.js
+++ b/lib/backend/postgres/cards.js
@@ -19,9 +19,6 @@ const SqlPath = require('./jsonschema2sql/sql-path')
 const CARDS_TABLE = 'cards'
 const CARDS_TRIGGER_COLUMNS = [
 	'active',
-	'version_major',
-	'version_minor',
-	'version_patch',
 	'name',
 	'tags',
 	'markers',


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Temporarily removing `version_*` columns from stream trigger columns while I continue to migrate these columns from null.