### PR TITLE
Add scope to session contract definition

### DIFF
--- a/lib/cards/session.js
+++ b/lib/cards/session.js
@@ -22,6 +22,10 @@ module.exports = {
 						expiration: {
 							type: 'string',
 							format: 'date-time'
+						},
+						scope: {
+							type: 'object',
+							additionalProperties: true
 						}
 					},
 					required: [


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

---

Add missing optional `scope` to `session` contract definition.