### PR TITLE
Remove fullTextSearch index on user slug

### DIFF
--- a/lib/cards/user.js
+++ b/lib/cards/user.js
@@ -24,8 +24,7 @@ module.exports = {
 				},
 				slug: {
 					type: 'string',
-					pattern: '^user-[a-z0-9-]+$',
-					fullTextSearch: true
+					pattern: '^user-[a-z0-9-]+$'
 				},
 				data: {
 					type: 'object',


### PR DESCRIPTION
This index was added recently to facilitate searching for users by slug in a full text search query. But this isn't very sensible as it requires the user to include the `user-` prefix in the search term - which they will never (want to) do! So I'm removing the fullTextSearch index and the CreateView lens will manually search for the user by slug using a regex search.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***
