### PR TITLE
Handle error events in postgres stream emitter

### DIFF
--- a/lib/backend/postgres/index.js
+++ b/lib/backend/postgres/index.js
@@ -875,6 +875,15 @@ module.exports = class PostgresBackend {
 		})
 
 		return async (id) => {
+			console.log('==================')
+			console.log({
+				schema
+			})
+			console.log('==================')
+			if (schema.title === 'throw') {
+				throw new Error('test')
+			}
+
 			const {
 				results,
 				queryTime

--- a/lib/backend/postgres/streams.js
+++ b/lib/backend/postgres/streams.js
@@ -228,6 +228,19 @@ class Stream extends EventEmitter {
 		})
 		streamer.register(id, this)
 		metrics.markStreamOpened(context, streamer.table)
+
+		// If an EventEmitter does not have at least one listener for the `error` event
+		// an exception will be raised and the nodeJS process will exit. To avoid
+		// this we always add an error listener that will log a warning.
+		// https://nodejs.org/api/events.html#events_error_events
+		this.on('error', (error) => {
+			logger.error(context, 'Encountered an error in stream', {
+				id,
+				table: streamer.table,
+				message: error.message,
+				schema
+			})
+		})
 	}
 
 	async query (select, schema, options) {


### PR DESCRIPTION
If there isn't a registed listener for an EventEmitter "error" event, an
exception will be raised and the nodeJS process will exit: see https://nodejs.org/api/events.html#events_error_events
This change adds a listener for the "error" event, and creates a log
message to prevent the process from crashing.

Fixes https://github.com/product-os/jellyfish/issues/5842

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>