### PR TITLE
Reinstate full-text-search on user slug

### DIFF
--- a/lib/cards/user.js
+++ b/lib/cards/user.js
@@ -24,7 +24,8 @@ module.exports = {
 				},
 				slug: {
 					type: 'string',
-					pattern: '^user-[a-z0-9-]+$'
+					pattern: '^user-[a-z0-9-]+$',
+					fullTextSearch: true
 				},
 				data: {
 					type: 'object',


### PR DESCRIPTION
User slugs are different! Sometimes we do want to search by username (without the leading `user-`) - which requires a fullTextSearch index.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>