### PR TITLE
Re-enable version columns as trigger targets

### DIFF
--- a/lib/backend/postgres/cards.js
+++ b/lib/backend/postgres/cards.js
@@ -19,6 +19,9 @@ const SqlPath = require('./jsonschema2sql/sql-path')
 const CARDS_TABLE = 'cards'
 const CARDS_TRIGGER_COLUMNS = [
 	'active',
+	'version_major',
+	'version_minor',
+	'version_patch',
 	'name',
 	'tags',
 	'markers',


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Reinstate `version_*` columns as trigger targets, previously temporarily disabled by https://github.com/product-os/jellyfish-core/pull/495 for version column migration work.