### PR TITLE
Use JellyfishLink widget for usernames and slugs/ids

### DIFF
--- a/lib/cards/mixins/ui-schema-defs.json
+++ b/lib/cards/mixins/ui-schema-defs.json
@@ -77,16 +77,22 @@
       }
     }
   },
+  "username": {
+    "ui:widget": "JellyfishLink",
+    "ui:value": "${source[5:]}",
+    "ui:options": {
+      "href": "https://jel.ly.fish/${source}"
+    }
+  },
   "usernameList": {
     "ui:options": {
       "orientation": "horizontal"
     },
     "items": {
-      "ui:widget": "Link",
+      "$ref": "#/username",
       "ui:value": "${source[5:]},",
       "ui:options": {
-        "mr": 1,
-        "href": "https://jel.ly.fish/${source}"
+        "mr": 1
       }
     }
   },
@@ -94,7 +100,7 @@
     "ui:widget": "Txt"
   },
   "idOrSlugLink": {
-    "ui:widget": "Link",
+    "ui:widget": "JellyfishLink",
     "ui:options": {
       "href": "https://jel.ly.fish/${source}"
     }


### PR DESCRIPTION
Also refactored slightly to expose a `username` UI schema (which should be used by `brainstorm-topic.data.reporter`).

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Fixes https://github.com/product-os/jellyfish/issues/5901

* [x] Depends on https://github.com/product-os/jellyfish/pull/5917