### PR TITLE
Add disableNotificationSound field to user profile

### DIFF
--- a/lib/cards/user.js
+++ b/lib/cards/user.js
@@ -219,6 +219,7 @@ module.exports = {
 									format: 'uuid'
 								},
 								sendCommand: {
+									title: 'Send command',
 									description: 'Command to send a message',
 									type: 'string',
 									default: 'shift+enter',
@@ -227,6 +228,12 @@ module.exports = {
 										'ctrl+enter',
 										'enter'
 									]
+								},
+								disableNotificationSound: {
+									title: 'Disable notification sound',
+									description: 'Do not play a sound when displaying notifications',
+									type: 'boolean',
+									default: false
 								},
 								starredViews: {
 									description: 'List of view slugs that are starred',
@@ -323,6 +330,9 @@ module.exports = {
 								then: '`${source}`',
 								else: null
 							}
+						},
+						disableNotificationSound: {
+							'ui:widget': 'Checkbox'
 						},
 						starredViews: {
 							$ref: path.join(__dirname, '/mixins/ui-schema-defs.json#/idOrSlugList')


### PR DESCRIPTION
If this value is set to true, no sound will be played when the user receives a notification.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

TBD: is there a better place to stick this setting in the user type schema? Probably in the future we'll have a whole load of more detailed settings related to notifications. But maybe this can exist here until then?

Relates to https://github.com/product-os/jellyfish/issues/5874

Obviously, we'll need to expose this on the front-end in the `MyUser` lens and also make use of it when calling `createNotification`.