### PR TITLE
Add index on name field to link type card

### DIFF
--- a/lib/cards/link.js
+++ b/lib/cards/link.js
@@ -83,6 +83,7 @@ module.exports = {
 			]
 		},
 		indexed_fields: [
+			[ 'name' ],
 			[ 'data.from.id', 'name', 'data.to.id' ]
 		]
 	}


### PR DESCRIPTION
Fixes https://github.com/product-os/jellyfish/issues/5884

Due to the way some queries for links are converted/optimized into SQL, it is necessary to index on the name field as well. Tested manually on production and verified this massively speeds up the slow queries.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>