### PR TITLE
Export cards in a DRY way.

### DIFF
--- a/lib/cards/index.js
+++ b/lib/cards/index.js
@@ -8,20 +8,26 @@ const {
 	initialize
 } = require('./mixins')
 
-module.exports = {
-	'action-request': initialize(require('./action-request')),
-	action: initialize(require('./action')),
-	card: initialize(require('./card')),
-	role: initialize(require('./role')),
-	org: initialize(require('./org')),
-	event: initialize(require('./event')),
-	link: initialize(require('./link')),
-	session: initialize(require('./session')),
-	type: initialize(require('./type')),
-	'user-admin': initialize(require('./user-admin')),
-	user: initialize(require('./user')),
-	'role-user-admin': initialize(require('./role-user-admin')),
-	view: initialize(require('./view')),
-	'oauth-provider': initialize(require('./oauth-provider')),
-	'oauth-client': initialize(require('./oauth-client'))
-}
+const cards = [
+	require('./action-request'),
+	require('./action'),
+	require('./card'),
+	require('./role'),
+	require('./org'),
+	require('./event'),
+	require('./link'),
+	require('./session'),
+	require('./type'),
+	require('./user-admin'),
+	require('./user'),
+	require('./role-user-admin'),
+	require('./view'),
+	require('./oauth-provider'),
+	require('./oauth-client')
+]
+
+module.exports = cards.reduce((acc, card) => {
+	const initializedCard = initialize(card)
+	acc[initializedCard.slug] = initializedCard
+	return acc
+}, {})


### PR DESCRIPTION
Just avoid having to manually enter the card slug and call initialize on each card.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>