### PR TITLE
Remove new version columns from returned cards

### DIFF
--- a/lib/backend/postgres/utils.js
+++ b/lib/backend/postgres/utils.js
@@ -54,6 +54,8 @@ exports.removeVersionFields = (row) => {
 		Reflect.deleteProperty(row, 'version_major')
 		Reflect.deleteProperty(row, 'version_minor')
 		Reflect.deleteProperty(row, 'version_patch')
+		Reflect.deleteProperty(row, 'version_prerelease')
+		Reflect.deleteProperty(row, 'version_build')
 	}
 
 	return row


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Remove `version_prerelease` and `version_build` from returned card data. This is necessary to add even though the columns do not yet exist because:
- We need to create the new `UNIQUE` constraint on the cards table manually as it locks the table and we want to have full control as to when this happens (not during support hours)
- We can't create the new `UNIQUE` constraint that contains these new columns if the columns do not exist, so we will create the columns and the new `UNIQUE` constraint manually during support off hours.
- But, sync errors occur if the columns are returned as part of the card. Example: `JellyfishSchemaMismatch: Path /version_prerelease does not exist in pull-request-mde...`

Which means, we should:
1. Merge this PR
2. Create new `version_prerelease` and `version_build` columns manually
3. Create new `UNIQUE` constraint that includes these columns manually
4. Push forward with https://github.com/product-os/jellyfish-core/pull/347