### PR TITLE
Remove version migration bootstrap steps

### DIFF
--- a/lib/backend/postgres/cards.js
+++ b/lib/backend/postgres/cards.js
@@ -109,32 +109,6 @@ exports.setup = async (context, connection, database, options = {}) => {
 		`)
 	}
 
-	// TODO: Remove this block once the production database reflects these changes.
-	await connection.any(`
-		BEGIN;
-
-		SELECT pg_advisory_xact_lock(${exports.INIT_LOCK});
-
-		ALTER TABLE ${table} ADD COLUMN IF NOT EXISTS version_prerelease TEXT NOT NULL DEFAULT '';
-		ALTER TABLE ${table} ADD COLUMN IF NOT EXISTS version_build TEXT NOT NULL DEFAULT '';
-		COMMENT ON COLUMN ${table}.version_build IS 'must be alphanum sortable i.e. rev01,rev02 and not rev1,...,rev10';
-
-		-- there is no "if not exists" for "add constraint"
-		DO $$
-		BEGIN
-			IF NOT EXISTS (SELECT constraint_name FROM information_schema.constraint_column_usage
-				WHERE constraint_name='${table}_slug_version_key') THEN
-
-				-- as it is a unique constraint we cannot use NOT VALID to speed things up
-				ALTER TABLE ${table} ADD CONSTRAINT ${table}_slug_version_key
-					UNIQUE (slug, version_major, version_minor, version_patch, version_prerelease, version_build);
-			END IF;
-		END;
-		$$;
-
-		COMMIT;
-	`)
-
 	/*
 	 * This query will give us a list of all the indexes
 	 * on a particular table.

--- a/lib/backend/postgres/links.js
+++ b/lib/backend/postgres/links.js
@@ -14,8 +14,6 @@ const LINK_TABLE = 'links'
 // Types cannot be created concurrently
 const CREATE_LINK_EDGE_TYPES_LOCK = 1043123456394267
 
-const INIT_LOCK = 1142043989439427
-
 exports.TABLE = LINK_TABLE
 
 exports.setup = async (context, connection, database, options) => {
@@ -59,32 +57,6 @@ exports.setup = async (context, connection, database, options) => {
 			toId UUID REFERENCES ${options.cards} (id) NOT NULL,
 			CONSTRAINT ${LINK_TABLE}_slug_version_key
 				UNIQUE (slug, version_major, version_minor, version_patch, version_prerelease, version_build))`)
-
-	// TODO: Remove this block once the production database reflects these changes.
-	await connection.any(`
-		BEGIN;
-
-		SELECT pg_advisory_xact_lock(${INIT_LOCK});
-
-		ALTER TABLE ${LINK_TABLE} ADD COLUMN IF NOT EXISTS version_prerelease TEXT NOT NULL DEFAULT '';
-		ALTER TABLE ${LINK_TABLE} ADD COLUMN IF NOT EXISTS version_build TEXT NOT NULL DEFAULT '';
-		COMMENT ON COLUMN ${LINK_TABLE}.version_build IS 'must be alphanum sortable i.e. rev01,rev02 and not rev1,...,rev10';
-
-		-- there is no "if not exists" for "add constraint"
-		DO $$
-		BEGIN
-			IF NOT EXISTS (SELECT constraint_name FROM information_schema.constraint_column_usage
-				WHERE constraint_name = '${LINK_TABLE}_slug_version_key') THEN
-
-				-- as it is a unique constraint we cannot use NOT VALID to speed things up
-				ALTER TABLE ${LINK_TABLE} ADD CONSTRAINT ${LINK_TABLE}_slug_version_key
-				UNIQUE (slug, version_major, version_minor, version_patch, version_prerelease, version_build);
-			END IF;
-		END;
-		$$;
-
-		COMMIT;
-	`)
 
 	const indexes = _.map(await connection.any(`
 		SELECT * FROM pg_indexes WHERE tablename = '${LINK_TABLE}'`),


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Remove unnecessary version column migration statements as these changes are already present on the production database.