### PR TITLE
Correctly deal with queries that select nothing inside JSONB objects

### DIFF
--- a/lib/backend/postgres/jsonschema2sql/select-map.js
+++ b/lib/backend/postgres/jsonschema2sql/select-map.js
@@ -344,7 +344,7 @@ module.exports = class SelectMap {
 		this.path.pop()
 
 		const jsonbObject = `jsonb_build_object(${args.join(', ')})`
-		if (this.path.isProcessingJsonProperty) {
+		if (this.path.isProcessingJsonProperty && propertiesAsLiterals.length > 0) {
 			return `${jsonbObject} - array(
 				SELECT key
 				FROM (VALUES (${propertiesAsLiterals.join('), (')})) AS f1(key)

--- a/test/integration/backend/index.spec.js
+++ b/test/integration/backend/index.spec.js
@@ -2766,6 +2766,65 @@ ava('.query() should resolve "limit" after resolving links', async (test) => {
 	])
 })
 
+ava('.query() should correctly build a JSONB object with no selected properties', async (test) => {
+	const card = await test.context.backend.upsertElement(test.context.context, {
+		type: 'card@1.0.0',
+		slug: test.context.generateRandomSlug(),
+		links: {},
+		version: '1.0.0',
+		tags: [],
+		markers: [],
+		requires: [],
+		capabilities: [],
+		created_at: new Date().toISOString(),
+		linked_at: {},
+		updated_at: null,
+		active: true,
+		data: {
+			test: {
+				content: 0
+			}
+		}
+	})
+
+	const results = await test.context.backend.query(test.context.context, {}, {
+		properties: {
+			id: {
+				const: card.id
+			},
+			data: {
+				properties: {
+					test: {
+						additionalProperties: false
+					}
+				}
+			}
+		}
+	})
+
+	test.deepEqual(results, [
+		{
+			id: card.id,
+			active: true,
+			capabilities: [],
+			created_at: card.created_at,
+			updated_at: card.updated_at,
+			linked_at: {},
+			markers: [],
+			name: null,
+			requires: [],
+			tags: [],
+			version: '1.0.0',
+			type: card.type,
+			slug: card.slug,
+			links: {},
+			data: {
+				test: {}
+			}
+		}
+	])
+})
+
 ava('adding a link should update the linked_at field', async (test) => {
 	const thread = await test.context.backend.upsertElement(test.context.context, {
 		type: 'thread@1.0.0',


### PR DESCRIPTION
When `additionalProperties: false`, JSONB content selection works
subtractively, first by fetching the whole object and then removing all
keys that were not explicitly selected. If no keys were selected at all,
the compiler would generate a query over `VALUES ()` which is not valid
SQL. This fix prevents subtraction from happening in this case,
replacing the expression with an empty JSONB object.

Fixes https://github.com/product-os/jellyfish/issues/6191

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>