### PR TITLE
Export errors, Kernel and Backend objects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,3 +21,10 @@ exports.create = async (context, cache, options) => {
 	await kernel.initialize(context)
 	return kernel
 }
+
+// TODO: A number of jellyfish modules import these objects from subpaths, which is an abomination.
+// It also makes converting said modules to typescript much more difficult.
+// Once everything is converted to typescript this situation needs to be straightened out.
+exports.Backend = Backend
+exports.errors = errors
+exports.Kernel = Kernel


### PR DESCRIPTION
 number of jellyfish modules import these objects from subpaths, which is an abomination.
It also makes converting said modules to typescript much more difficult.
Once everything is converted to typescript this situation needs to be straightened out.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>