### PR TITLE
Add title to user card email property

### DIFF
--- a/lib/cards/user.js
+++ b/lib/cards/user.js
@@ -87,6 +87,7 @@ module.exports = {
 							]
 						},
 						email: {
+							title: 'Email',
 							oneOf: [
 								{
 									title: 'List of email addresses',


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Add a `title` to the `email` property of `user` cards for display in views.