### PR TITLE
Correctly wait for the redis client to quit when disconnecting cache

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -90,15 +90,22 @@ module.exports = class Cache {
 	 * const cache = new Cache()
 	 * await cache.disconnect()
 	 */
-	// eslint-disable-next-line class-methods-use-this
 	async disconnect () {
 		if (this.client) {
-			this.client.removeAllListeners()
-			await this.client.quit()
-			this.client = null
-		}
+			await new Promise((resolve) => {
+				this.client.removeAllListeners()
+				this.client.quit(() => {
+					this.client = null
+					resolve()
+				})
+			})
 
-		return Promise.resolve()
+			// This is because redis.quit() creates a thread to close the connection.
+			// We wait until all threads have been run once to ensure the connection closes.
+			await new Promise((resolve) => {
+				setImmediate(resolve)
+			})
+		}
 	}
 
 	/**


### PR DESCRIPTION
See https://stackoverflow.com/a/54560610 for more detail on this solution

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>