### PR TITLE
Reduce granularity of logger instances

### DIFF
--- a/lib/backend/postgres/cards.js
+++ b/lib/backend/postgres/cards.js
@@ -7,7 +7,7 @@
 const _ = require('lodash')
 const Bluebird = require('bluebird')
 const pgFormat = require('pg-format')
-const logger = require('@balena/jellyfish-logger').getLogger(__filename)
+const logger = require('@balena/jellyfish-logger').getLogger('jellyfish-core')
 const {
 	v4: uuidv4
 } = require('uuid')

--- a/lib/backend/postgres/index.js
+++ b/lib/backend/postgres/index.js
@@ -11,7 +11,7 @@ const {
 const pgp = require('./pg-promise')
 const Bluebird = require('bluebird')
 const skhema = require('skhema')
-const logger = require('@balena/jellyfish-logger').getLogger(__filename)
+const logger = require('@balena/jellyfish-logger').getLogger('jellyfish-worker')
 const assert = require('@balena/jellyfish-assert')
 const jsonschema2sql = require('./jsonschema2sql')
 const links = require('./links')

--- a/lib/backend/postgres/links.js
+++ b/lib/backend/postgres/links.js
@@ -5,7 +5,7 @@
  */
 
 const _ = require('lodash')
-const logger = require('@balena/jellyfish-logger').getLogger(__filename)
+const logger = require('@balena/jellyfish-logger').getLogger('jellyfish-core')
 const utils = require('./utils')
 
 const LINK_ORIGIN_PROPERTY = '$link'

--- a/lib/backend/postgres/markers.js
+++ b/lib/backend/postgres/markers.js
@@ -6,7 +6,7 @@
 
 const _ = require('lodash')
 const debouncePromise = require('debounce-promise')
-const logger = require('@balena/jellyfish-logger').getLogger(__filename)
+const logger = require('@balena/jellyfish-logger').getLogger('jellyfish-core')
 const environment = require('@balena/jellyfish-environment').defaultEnvironment
 const LINK_TYPE = 'has member'
 

--- a/lib/backend/postgres/streams.js
+++ b/lib/backend/postgres/streams.js
@@ -7,7 +7,7 @@
 const _ = require('lodash')
 const pgFormat = require('pg-format')
 const EventEmitter = require('events').EventEmitter
-const logger = require('@balena/jellyfish-logger').getLogger(__filename)
+const logger = require('@balena/jellyfish-logger').getLogger('jellyfish-core')
 const {
 	v4: uuidv4
 } = require('uuid')

--- a/lib/backend/postgres/utils.js
+++ b/lib/backend/postgres/utils.js
@@ -5,7 +5,7 @@
  */
 
 const _ = require('lodash')
-const logger = require('@balena/jellyfish-logger').getLogger(__filename)
+const logger = require('@balena/jellyfish-logger').getLogger('jellyfish-worker')
 
 // List of Postgres error codes we can safely ignore during initial db setup.
 // All error codes: https://www.postgresql.org/docs/12/errcodes-appendix.html

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -13,7 +13,7 @@ const errors = require('./errors')
 const views = require('./views')
 const CARDS = require('./cards')
 const permissionFilter = require('./permission-filter')
-const logger = require('@balena/jellyfish-logger').getLogger(__filename)
+const logger = require('@balena/jellyfish-logger').getLogger('jellyfish-core')
 const metrics = require('@balena/jellyfish-metrics')
 
 const flattenSelected = (selected) => {


### PR DESCRIPTION
Winston doesn't handle large amounts of logger instances particularly
well and the low level of granularity used here is overkill.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>