### PR TITLE
Add indexes on data fields to assist in querying links efficiently

### DIFF
--- a/lib/cards/link.ts
+++ b/lib/cards/link.ts
@@ -73,6 +73,13 @@ export const link = {
 			},
 			required: ['name', 'type', 'links', 'data'],
 		},
-		indexed_fields: [['name'], ['data.from.id', 'name', 'data.to.id']],
+		indexed_fields: [
+			['name'],
+			['data.from.id'],
+			['data.from.type'],
+			['data.to.id'],
+			['data.to.type'],
+			['data.from.id', 'name', 'data.to.id'],
+		],
 	},
 };


### PR DESCRIPTION
Sometimes we will need to query for links as follows:
* Find all links to or from this specific contract (`data.from.id` or `data.to.id`)
* Find all links to or from this type of contract (`data.from.type` or `data.to.type`)

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Draft until we manually create these indexes on production during quiet times so that we don't overload the system when this change gets deployed to production.