### PR TITLE
Add support for a query mask

### DIFF
--- a/test/integration/kernel.spec.ts
+++ b/test/integration/kernel.spec.ts
@@ -3208,6 +3208,68 @@ describe('Kernel', () => {
 			]);
 		});
 
+		it('should filter cards by the options.mask schema if set', async () => {
+			const insertedCard = await ctx.kernel.insertCard(
+				ctx.context,
+				ctx.kernel.sessions!.admin,
+				{
+					slug: ctx.generateRandomSlug(),
+					type: 'card@1.0.0',
+					data: {
+						sequence: 1,
+					},
+				},
+			);
+
+			const query: JSONSchema = {
+				type: 'object',
+				properties: {
+					id: {
+						const: insertedCard.id,
+					},
+				},
+			};
+
+			const mask: JSONSchema = {
+				type: 'object',
+				properties: {
+					type: {
+						const: 'foo@1.0.0',
+					},
+				},
+			};
+
+			const resultWithNoMask = await ctx.kernel.query(
+				ctx.context,
+				ctx.kernel.sessions!.admin,
+				query,
+				{},
+			);
+
+			expect(
+				resultWithNoMask.map((card) => {
+					return {
+						id: card.id,
+					};
+				}),
+			).toEqual([
+				{
+					id: insertedCard.id,
+				},
+			]);
+
+			const resultWithMask = await ctx.kernel.query(
+				ctx.context,
+				ctx.kernel.sessions!.admin,
+				query,
+				{
+					mask,
+				},
+			);
+
+			expect(resultWithMask.length).toBe(0);
+		});
+
 		it('should be able to skip and limit linked cards', async () => {
 			const parent = await ctx.kernel.insertCard(
 				ctx.context,


### PR DESCRIPTION
When querying at the kernel level, we now support passing an optional JSON schema `mask` in the `options` argument. If set, this mask will be merged with the original query before the DB is queried.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Relates to https://github.com/product-os/jellyfish-client-sdk/pull/427