### PR TITLE
change test Dockerfile to use node 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:14
 
 WORKDIR /usr/src/jellyfish
 


### PR DESCRIPTION
open-balena-base has switched quite some time ago,
so our production code is already using 14

Change-type: patch
Signed-off-by: Martin Rauscher <martin@balena.io>