### PR TITLE
Optimize auto-linting on commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx}": [
-      "npm run lint-fix",
-      "git add ."
+      "balena-lint --fix"
     ]
   },
   "author": "Balena.io. <hello@balena.io>",


### PR DESCRIPTION
This means we only run lint-fix on the files that are actually part of the commit rather than every file and saves some time for each commit