### PR TITLE
Add more version tests

### DIFF
--- a/test/integration/backend/index.spec.ts
+++ b/test/integration/backend/index.spec.ts
@@ -408,64 +408,6 @@ describe('backend', () => {
 			).toEqual(result);
 		});
 
-		it('should insert an element with pre-release version data', async () => {
-			const id = ctx.generateRandomID();
-			const result = await ctx.backend.insertElement(ctx.context, {
-				id,
-				active: true,
-				slug: ctx.generateRandomSlug(),
-				version: '1.0.0-alpha',
-				links: {},
-				tags: [],
-				data: {},
-				markers: [],
-				requires: [],
-				linked_at: {},
-				capabilities: [],
-				created_at: new Date().toISOString(),
-				type: 'card@1.0.0',
-			});
-
-			expect(result.id).toBe(id);
-
-			const element = await ctx.backend.getElementById(ctx.context, result.id);
-
-			expect(
-				Object.assign({}, element, {
-					id: result.id,
-				}),
-			).toEqual(result);
-		});
-
-		it('should insert an element with pre-release and build version data', async () => {
-			const id = ctx.generateRandomID();
-			const result = await ctx.backend.insertElement(ctx.context, {
-				id,
-				active: true,
-				slug: ctx.generateRandomSlug(),
-				version: '1.0.0-alpha+001',
-				links: {},
-				tags: [],
-				data: {},
-				markers: [],
-				requires: [],
-				linked_at: {},
-				capabilities: [],
-				created_at: new Date().toISOString(),
-				type: 'card@1.0.0',
-			});
-
-			expect(result.id).toBe(id);
-
-			const element = await ctx.backend.getElementById(ctx.context, result.id);
-
-			expect(
-				Object.assign({}, element, {
-					id: result.id,
-				}),
-			).toEqual(result);
-		});
-
 		it('should fail to insert an element with an existent id', async () => {
 			const result1 = await ctx.backend.insertElement(ctx.context, {
 				slug: ctx.generateRandomSlug(),
@@ -966,50 +908,6 @@ describe('backend', () => {
 					active: true,
 				} as any),
 			).rejects.toThrow(errors.JellyfishDatabaseError);
-		});
-
-		it('should insert a card with prerelease version data', async () => {
-			const result = await ctx.backend.upsertElement(ctx.context, {
-				slug: ctx.generateRandomSlug(),
-				type: 'card@1.0.0',
-				version: '1.0.0-alpha',
-				links: {},
-				tags: [],
-				linked_at: {},
-				data: {},
-				markers: [],
-				requires: [],
-				capabilities: [],
-				created_at: new Date().toISOString(),
-				active: true,
-			});
-
-			expect(result.id).not.toBe('example');
-			const element = await ctx.backend.getElementById(ctx.context, result.id);
-
-			expect(element).toEqual(result);
-		});
-
-		it('should insert a card with prerelease and build version data', async () => {
-			const result = await ctx.backend.upsertElement(ctx.context, {
-				slug: ctx.generateRandomSlug(),
-				type: 'card@1.0.0',
-				version: '1.0.0-alpha+001',
-				links: {},
-				tags: [],
-				linked_at: {},
-				data: {},
-				markers: [],
-				requires: [],
-				capabilities: [],
-				created_at: new Date().toISOString(),
-				active: true,
-			});
-
-			expect(result.id).not.toBe('example');
-			const element = await ctx.backend.getElementById(ctx.context, result.id);
-
-			expect(element).toEqual(result);
 		});
 
 		it('should handle multiple parallel insertions on the same slug', async () => {

--- a/test/integration/kernel.spec.ts
+++ b/test/integration/kernel.spec.ts
@@ -1687,6 +1687,123 @@ describe('Kernel', () => {
 			expect(element2).toEqual(card2);
 		});
 
+		it('should insert an element with pre-release version data', async () => {
+			const version = '1.0.0-alpha';
+			const slug = ctx.generateRandomSlug({
+				prefix: 'card',
+			});
+			const result = await ctx.kernel.insertCard(
+				ctx.context,
+				ctx.kernel.sessions!.admin,
+				{
+					slug,
+					type: 'card@1.0.0',
+					version,
+					data: {},
+				},
+			);
+			const element = await ctx.kernel.getCardBySlug(
+				ctx.context,
+				ctx.kernel.sessions!.admin,
+				`${result.slug}@${version}`,
+			);
+
+			expect(element!.version).toEqual(version);
+		});
+
+		it('should insert an element with pre-release and build version data', async () => {
+			const version = '1.0.0-alpha+001';
+			const result = await ctx.kernel.insertCard(
+				ctx.context,
+				ctx.kernel.sessions!.admin,
+				{
+					slug: ctx.generateRandomSlug(),
+					type: 'card@1.0.0',
+					version,
+					data: {},
+				},
+			);
+			const element = await ctx.kernel.getCardBySlug(
+				ctx.context,
+				ctx.kernel.sessions!.admin,
+				`${result.slug}@${version}`,
+			);
+
+			expect(element!.version).toEqual(version);
+		});
+
+		it('should insert multiple prereleases on same version', async () => {
+			const slug = ctx.generateRandomSlug();
+			const version1 = '1.0.0-alpha';
+			const version2 = '1.0.0-beta';
+			const results = [
+				await ctx.kernel.insertCard(ctx.context, ctx.kernel.sessions!.admin, {
+					slug,
+					type: 'card@1.0.0',
+					version: version1,
+					data: {},
+				}),
+				await ctx.kernel.insertCard(ctx.context, ctx.kernel.sessions!.admin, {
+					slug,
+					type: 'card@1.0.0',
+					version: version2,
+					data: {},
+				}),
+			];
+			const elements = [
+				await ctx.kernel.getCardBySlug(
+					ctx.context,
+					ctx.kernel.sessions!.admin,
+					`${results[0].slug}@${version1}`,
+				),
+				await ctx.kernel.getCardBySlug(
+					ctx.context,
+					ctx.kernel.sessions!.admin,
+					`${results[1].slug}@${version2}`,
+				),
+			];
+
+			// Check that the cards have the same slug, but different versions
+			expect(elements[0]!.slug).toEqual(elements[1]!.slug);
+			expect(elements[0]!.version).toEqual(version1);
+			expect(elements[1]!.version).toEqual(version2);
+		});
+
+		it('should insert multiple builds on same prerelease version', async () => {
+			const slug = ctx.generateRandomSlug();
+			const version1 = '1.0.0-alpha+001';
+			const version2 = '1.0.0-alpha+002';
+			await ctx.kernel.insertCard(ctx.context, ctx.kernel.sessions!.admin, {
+				slug,
+				type: 'card@1.0.0',
+				version: version1,
+				data: {},
+			});
+			await ctx.kernel.insertCard(ctx.context, ctx.kernel.sessions!.admin, {
+				slug,
+				type: 'card@1.0.0',
+				version: version2,
+				data: {},
+			});
+			const elements = [
+				await ctx.kernel.getCardBySlug(
+					ctx.context,
+					ctx.kernel.sessions!.admin,
+					`${slug}@${version1}`,
+				),
+				await ctx.kernel.getCardBySlug(
+					ctx.context,
+					ctx.kernel.sessions!.admin,
+					`${slug}@${version2}`,
+				),
+			];
+
+			// Check that the cards have the same slug, but different versions
+			expect(elements[0]!.slug).toEqual(elements[1]!.slug);
+			expect(elements[0]!.version).toEqual(version1);
+			expect(elements[1]!.version).toEqual(version2);
+		});
+
 		it('should be able to insert a card', async () => {
 			const slug = ctx.generateRandomSlug({
 				prefix: 'hello-world',


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

- Adds a couple more build and prerelease version unit tests.
- Moves these tests to the `kernel` layer instead of the `backend` layer.