### PR TITLE
Remove redundant relationships definitions

### DIFF
--- a/lib/cards/org.ts
+++ b/lib/cards/org.ts
@@ -47,14 +47,5 @@ export const org = {
 			},
 			required: ['name'],
 		},
-		meta: {
-			relationships: [
-				{
-					title: 'Members',
-					link: 'has member',
-					type: 'user',
-				},
-			],
-		},
 	},
 };

--- a/lib/cards/user.ts
+++ b/lib/cards/user.ts
@@ -343,11 +343,6 @@ export const user = {
 		meta: {
 			relationships: [
 				{
-					title: 'Contact',
-					link: 'has attached contact',
-					type: 'contact',
-				},
-				{
 					title: 'Sales',
 					query: [
 						{
@@ -413,36 +408,6 @@ export const user = {
 							properties: {
 								type: {
 									const: 'support-thread@1.0.0',
-								},
-							},
-							additionalProperties: true,
-						},
-					],
-				},
-				{
-					title: 'Owned conversations',
-					query: [
-						{
-							$$links: {
-								'is owned by': {
-									type: 'object',
-									properties: {
-										type: {
-											const: 'user@1.0.0',
-										},
-										id: {
-											const: {
-												$eval: 'result.id',
-											},
-										},
-									},
-									required: ['id'],
-								},
-							},
-							type: 'object',
-							properties: {
-								type: {
-									enum: ['support-thread@1.0.0', 'sales-thread@1.0.0'],
 								},
 							},
 							additionalProperties: true,


### PR DESCRIPTION
These are now materialized automatically on the front-end using link constraints.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>