### PR TITLE
Fix type index definition generation

### DIFF
--- a/lib/backend/postgres/index.ts
+++ b/lib/backend/postgres/index.ts
@@ -18,7 +18,7 @@ import * as streams from './streams';
 import * as utils from './utils';
 import * as markers from './markers';
 import pgp from './pg-promise';
-import { JSONSchema } from '@balena/jellyfish-types';
+import { core, JSONSchema } from '@balena/jellyfish-types';
 import {
 	Context,
 	Contract,
@@ -368,7 +368,7 @@ const upsertObject = async <T extends Contract = Contract>(
 	if (baseType === 'type') {
 		if (insertedObject.data.indexed_fields) {
 			for (const fields of (insertedObject as any).data.indexed_fields) {
-				await backend.createTypeIndex(context, fields, insertedObject.slug);
+				await backend.createTypeIndex(context, fields, insertedObject);
 			}
 		}
 		// Find full-text search fields for type cards and create search indexes
@@ -1130,8 +1130,12 @@ export class PostgresBackend implements Queryable {
 	/*
 	 * Creates a partial index on "fields" constrained by the provided "type"
 	 */
-	async createTypeIndex(context: Context, fields: string[], type: string) {
-		await cards.createTypeIndex(context, this, fields, type);
+	async createTypeIndex(
+		context: Context,
+		fields: string[],
+		schema: core.ContractDefinition<any>,
+	) {
+		await cards.createTypeIndex(context, this, fields, schema);
 	}
 	/*
 	 * Creates a partial index on fields denoted as being targets for full-text searches

--- a/lib/backend/postgres/jsonschema2sql/table-index.spec.ts
+++ b/lib/backend/postgres/jsonschema2sql/table-index.spec.ts
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import { generateTypeIndexPredicate, getFieldType } from './table-index';
+
+describe('getFieldType()', () => {
+	it('should accurately get field types from a contract type schema', () => {
+		const type = 'message';
+		const schema = {
+			slug: 'foobar',
+			type: 'type@1.0.0',
+			data: {
+				schema: {
+					type: 'object',
+					properties: {
+						data: {
+							type: 'object',
+							properties: {
+								payload: {
+									type: 'object',
+									required: ['message'],
+									properties: {
+										mentionsUser: {
+											type: 'array',
+											items: {
+												type: 'string',
+											},
+										},
+										message: {
+											type: 'string',
+											format: 'markdown',
+											fullTextSearch: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		};
+
+		expect(getFieldType(type, schema, 'data')).toEqual('object');
+		expect(getFieldType(type, schema, 'data.payload')).toEqual('object');
+		expect(getFieldType(type, schema, 'data.payload.message')).toEqual(
+			'string',
+		);
+		expect(getFieldType(type, schema, 'data.payload.mentionsUser')).toEqual(
+			'array',
+		);
+	});
+
+	it('should throw error when no type is found', () => {
+		expect.hasAssertions();
+		try {
+			getFieldType(
+				'message',
+				{
+					slug: 'foobar',
+					type: 'foobar@1.0.0',
+					data: {},
+				},
+				'data.payload.message',
+			);
+		} catch (error) {
+			expect(error.message).toEqual(
+				'Could not find type for field data.payload.message on message',
+			);
+		}
+	});
+});
+
+describe('generateTypeIndexPredicate()', () => {
+	it('should generate the correct predicate for a top level field', () => {
+		const schema = {
+			slug: 'foobar',
+			type: 'type@1.0.0',
+			data: {
+				schema: {
+					type: 'object',
+					properties: {
+						name: {
+							type: 'string',
+						},
+					},
+					required: ['name'],
+				},
+				indexed_fields: [['name']],
+			},
+		};
+		const predicate = generateTypeIndexPredicate(
+			schema.data.indexed_fields[0],
+			schema,
+		);
+		expect(predicate).toEqual(
+			`USING btree (name) WHERE type='${schema.slug}@1.0.0'`,
+		);
+	});
+
+	it('should generate the correct predicate for multiple top level fields', () => {
+		const schema = {
+			slug: 'foobar',
+			type: 'type@1.0.0',
+			data: {
+				schema: {
+					type: 'object',
+					properties: {
+						name: {
+							type: 'string',
+						},
+						slug: {
+							type: 'string',
+						},
+					},
+					required: ['name', 'slug'],
+				},
+				indexed_fields: [['name', 'slug']],
+			},
+		};
+
+		const predicate = generateTypeIndexPredicate(
+			schema.data.indexed_fields[0],
+			schema,
+		);
+		expect(predicate).toEqual(
+			`USING btree (name,slug) WHERE type='${schema.slug}@1.0.0'`,
+		);
+	});
+
+	it('should generate the correct predicate for a top level array field', () => {
+		const schema = {
+			slug: 'foobar',
+			type: 'type@1.0.0',
+			data: {
+				schema: {
+					type: 'object',
+					properties: {
+						tags: {
+							type: 'array',
+							items: {
+								type: 'string',
+							},
+						},
+					},
+					required: ['tags'],
+				},
+				indexed_fields: [['tags']],
+			},
+		};
+		const predicate = generateTypeIndexPredicate(
+			schema.data.indexed_fields[0],
+			schema,
+		);
+		expect(predicate).toEqual(
+			`USING gin (tags) WHERE type='${schema.slug}@1.0.0'`,
+		);
+	});
+
+	it('should generate the correct predicate for a JSONB field', () => {
+		const schema = {
+			slug: 'foobar',
+			type: 'type@1.0.0',
+			data: {
+				schema: {
+					type: 'object',
+					properties: {
+						data: {
+							type: 'object',
+							properties: {
+								name: {
+									type: 'string',
+								},
+							},
+							required: ['name'],
+						},
+					},
+					required: ['data'],
+				},
+				indexed_fields: [['data.name']],
+			},
+		};
+		const predicate = generateTypeIndexPredicate(
+			schema.data.indexed_fields[0],
+			schema,
+		);
+		expect(predicate).toEqual(
+			`USING btree (((data#>>'{"name"}')::text)) WHERE type='${schema.slug}@1.0.0'`,
+		);
+	});
+
+	it('should generate the correct predicate for multiple JSONB fields', () => {
+		const schema = {
+			slug: 'foobar',
+			type: 'type@1.0.0',
+			data: {
+				schema: {
+					type: 'object',
+					properties: {
+						name: {
+							type: 'string',
+						},
+						slug: {
+							type: 'string',
+						},
+					},
+					required: ['name', 'slug'],
+				},
+				indexed_fields: [['name', 'slug']],
+			},
+		};
+
+		const predicate = generateTypeIndexPredicate(
+			schema.data.indexed_fields[0],
+			schema,
+		);
+		expect(predicate).toEqual(
+			`USING btree (name,slug) WHERE type='${schema.slug}@1.0.0'`,
+		);
+	});
+
+	it('should generate the correct predicate for a JSONB array field', () => {
+		const schema = {
+			slug: 'foobar',
+			type: 'type@1.0.0',
+			data: {
+				schema: {
+					type: 'object',
+					properties: {
+						data: {
+							type: 'object',
+							properties: {
+								tags: {
+									type: 'array',
+									items: {
+										type: 'string',
+									},
+								},
+							},
+							required: ['tags'],
+						},
+					},
+					required: ['data'],
+				},
+				indexed_fields: [['data.tags']],
+			},
+		};
+		const predicate = generateTypeIndexPredicate(
+			schema.data.indexed_fields[0],
+			schema,
+		);
+		expect(predicate).toEqual(
+			`USING gin ((data#>'{"tags"}')) WHERE type='${schema.slug}@1.0.0'`,
+		);
+	});
+});

--- a/lib/backend/postgres/jsonschema2sql/table-index.ts
+++ b/lib/backend/postgres/jsonschema2sql/table-index.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import { core } from '@balena/jellyfish-types';
+import * as _ from 'lodash';
+import * as pgFormat from 'pg-format';
+import { SqlPath } from './sql-path';
+
+/**
+ * @param type - contract type
+ * @param schema - type contract schema
+ * @param fieldPath - path to field in schema
+ * @returns string representation of field type
+ *
+ * @example
+ * getFieldType('message', {...}, 'data.payload.message');
+ */
+export function getFieldType(
+	contractType: string,
+	schema: core.ContractDefinition<any>,
+	fieldPath: string,
+): string {
+	const fullPath = ['data', 'schema', 'properties'].concat(
+		fieldPath.replace(/\./g, '.properties.').split('.'),
+		['type'],
+	);
+	const fieldType = _.get(schema, fullPath);
+
+	// Error out if no type is found for provided path, invalid schema or indexed_fields.
+	if (!_.isString(fieldType)) {
+		throw new Error(
+			`Could not find type for field ${fieldPath} on ${contractType}`,
+		);
+	}
+	return fieldType;
+}
+
+/**
+ *
+ * @param fields - fields to index
+ * @param schema - card schema
+ * @returns generated predicate for CREATE INDEX statement
+ */
+export function generateTypeIndexPredicate(
+	fields: string[],
+	schema: core.ContractDefinition<any>,
+): string {
+	const type = schema.slug;
+	const columns = [];
+	let indexType = 'btree';
+	let asText = true;
+
+	for (const path of fields) {
+		// Use gin for indexes on array fields
+		const isArray = getFieldType(type, schema, path) === 'array';
+		if (fields.length === 1 && isArray) {
+			indexType = 'gin';
+			asText = false;
+		}
+
+		// Generate and add field selector
+		const sqlPath = SqlPath.fromArray(path.split('.'));
+		let column = sqlPath.toSql('', { asText }).replace(/\./, '');
+		if (sqlPath.isProcessingJsonProperty) {
+			column = `(${column})`;
+		}
+		columns.push(column);
+	}
+
+	const versionedType = type.includes('@') ? type : `${type}@1.0.0`;
+	return `USING ${indexType} (${columns.join(
+		',',
+	)}) WHERE type=${pgFormat.literal(versionedType)}`;
+}

--- a/test/integration/helpers.ts
+++ b/test/integration/helpers.ts
@@ -14,11 +14,11 @@ export interface KernelContext extends helpers.BackendContext {
 export const before = async (
 	options: { suffix?: string; skipConnect?: boolean } = {},
 ): Promise<KernelContext> => {
-	const ctx: helpers.BackendContext &
-		Partial<KernelContext> = await helpers.before({
-		skipConnect: true,
-		suffix: options.suffix,
-	});
+	const ctx: helpers.BackendContext & Partial<KernelContext> =
+		await helpers.before({
+			skipConnect: true,
+			suffix: options.suffix,
+		});
 
 	if (options.suffix) {
 		await ctx.backend.connect(ctx.context);


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Resolves https://github.com/product-os/jellyfish-core/issues/867

We currently have a number of type indexes that do not match the generated SQL queries. See the issue mentioned above for current problematic index definitions and data-based evidence that the new definitions presented in this PR will be used by the Postgres planner and should result in faster queries.

This PR focuses on fixing type index definitions for JSONB child fields, namely:
- Using the same selector notation that is used in `SELECT` statements (e.g. `data#>>'{"status"}'` instead of `data->>'status'`)
- Using `gin` for indexes on arrays ([docs](https://www.postgresql.org/docs/current/datatype-json.html#JSON-INDEXING))

Am planning on also checking non-JSONB related type indexes, but the vast majority are JSONB so we can get the biggest wins by fixing these up first.

---

Subsequent PRs:
- https://github.com/product-os/jellyfish-plugin-github/pull/307
- https://github.com/product-os/jellyfish-plugin-default/pull/594
- https://github.com/product-os/jellyfish-plugin-default/pull/595
- https://github.com/product-os/jellyfish-core/pull/799