### PR TITLE
Enforce loop as string or null on insert

### DIFF
--- a/lib/backend/postgres/cards.ts
+++ b/lib/backend/postgres/cards.ts
@@ -452,7 +452,7 @@ export const upsert = async (
 		{},
 		new Date(insertedObject.created_at),
 		insertedObject.updated_at ? new Date(insertedObject.updated_at) : null,
-		insertedObject.loop,
+		typeof insertedObject.loop === 'string' ? insertedObject.loop : null,
 	];
 	let results = null;
 	// Its very important, for concurrency issues, that inserts/upserts


### PR DESCRIPTION
Treat loop just like we do with the optional name field.

Note - we already validate the loop field in the kernel so this shouldn't be a problem in practice but it's worth being consistent and safe at the backend level as well.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>