### PR TITLE
Ensure that backend types are included in compiled build

### DIFF
--- a/lib/backend/postgres/types.ts
+++ b/lib/backend/postgres/types.ts
@@ -4,9 +4,10 @@
  * Proprietary and confidential.
  */
 
-import type pgPromise = require('pg-promise');
-import type pg = require('pg-promise/typescript/pg-subset');
+import pgPromise = require('pg-promise');
+import pg = require('pg-promise/typescript/pg-subset');
 import type { PostgresBackend } from '.';
+import { SqlPath } from './jsonschema2sql/sql-path';
 
 export type DatabaseConnection = pgPromise.IDatabase<{}, pg.IClient>;
 export type DatabaseBackend = PostgresBackend;


### PR DESCRIPTION
With our tsc configuration, `*.d.ts` files are ignored by the compiler
and won't be copied across to the output directory, this causes problems
when downstream projects are trying to use types defined here.
This change simply changes the extension to `.ts`, causing the file to
be included in the build output.

See https://stackoverflow.com/a/56440335 for more detail

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>