### PR TITLE
Specify loop widget for the loop field

### DIFF
--- a/lib/cards/mixins/with-ui-schema.ts
+++ b/lib/cards/mixins/with-ui-schema.ts
@@ -21,6 +21,9 @@ export const baseUiSchema = {
 			definitions: {
 				form: {
 					'ui:order': ['name', 'loop', 'tags', 'data', '*'],
+					loop: {
+						'ui:widget': 'LoopSelect',
+					},
 				},
 			},
 			snippet: {


### PR DESCRIPTION
Note - if the loop widget is not found, this 'ui:widget' field will be ignored.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Depends on: https://github.com/product-os/jellyfish/pull/6796