### PR TITLE
Use ES6 module export for create function

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,10 @@ This library contains email integration functionality for use in Jellyfish.
 Below is an example how to use this library:
 
 ```js
-const core = require('@balena/jellyfish-core');
+import { MemoryCache, create } from '@balena/jellyfish-core';
 
 const cache = new core.MemoryCache(environment.redis);
-const jellyfish = await core.create(context, cache, {
+const jellyfish = await create(context, cache, {
 	backend: environment.database.options,
 });
 ```

--- a/lib/backend/postgres/cards.ts
+++ b/lib/backend/postgres/cards.ts
@@ -280,7 +280,7 @@ export const getById = async (
 		table?: string;
 	} = {},
 ) => {
-	const table = options.table || exports.TABLE;
+	const table = options.table || TABLE;
 	logger.debug(context, 'Getting element by id', {
 		id,
 		table,
@@ -306,7 +306,7 @@ export const getBySlug = async (
 		lock?: boolean;
 	} = {},
 ) => {
-	const table = options.table || exports.TABLE;
+	const table = options.table || TABLE;
 
 	logger.debug(context, 'Getting element by slug', {
 		slug,
@@ -366,7 +366,7 @@ export const getManyById = async (
 		table?: string;
 	} = {},
 ) => {
-	const table = options.table || exports.TABLE;
+	const table = options.table || TABLE;
 	logger.debug(context, 'Batch get by id', {
 		count: ids.length,
 		table,
@@ -397,7 +397,7 @@ export const upsert = async <T extends Contract = Contract>(
 		replace?: boolean;
 	} = {},
 ): Promise<T> => {
-	const table = options.table || exports.TABLE;
+	const table = options.table || TABLE;
 	assert.INTERNAL(
 		context,
 		object.slug,
@@ -565,7 +565,7 @@ export const materializeLink = async (
 		table?: string;
 	} = {},
 ) => {
-	const table = options.table || exports.TABLE;
+	const table = options.table || TABLE;
 	try {
 		const sql = `UPDATE ${table}
 				SET linked_at = $1::jsonb

--- a/lib/backend/postgres/jsonschema2sql/text-search.ts
+++ b/lib/backend/postgres/jsonschema2sql/text-search.ts
@@ -16,7 +16,7 @@ import * as pgFormat from 'pg-format';
  * @returns {String} to_tsvector function call
  *
  * @example
- * const result = exports.toTSVector('cards.tags', false, true)
+ * const result = toTSVector('cards.tags', false, true)
  */
 export const toTSVector = (
 	path: string,
@@ -42,7 +42,7 @@ export const toTSVector = (
  *
  * @example
  * const term = 'test'
- * const result = exports.toTSQuery(term)
+ * const result = toTSQuery(term)
  */
 export const toTSQuery = (term: string): string => {
 	return `plainto_tsquery('english', ${pgFormat.literal(term)})`;

--- a/lib/backend/postgres/utils.ts
+++ b/lib/backend/postgres/utils.ts
@@ -44,7 +44,7 @@ export const convertDatesToISOString = (row: any) => {
  * @param {Boolean} unique - declare index as UNIQUE (optional)
  *
  * @example
- * await exports.createIndex(context, connection, 'cards', 'example_idx', 'USING btree (updated_at)')
+ * await createIndex(context, connection, 'cards', 'example_idx', 'USING btree (updated_at)')
  */
 export const createIndex = async (
 	context: Context,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -14,7 +14,7 @@ export * as cardMixins from './cards/mixins';
 export const MemoryCache = Cache;
 export const cards = CARDS;
 
-exports.create = async (context: any, cache: any, options: any) => {
+export const create = async (context: any, cache: any, options: any) => {
 	const backend = new CoreBackend(cache, coreErrors, options.backend);
 	const kernel = new CoreKernel(backend);
 	await kernel.initialize(context);


### PR DESCRIPTION
Also removed other references to 'exports'.

Change-type: major
Signed-off-by: Graham McCulloch <graham@balena.io>

***

The `create` function was somehow left as a commonjs export. So this fix converts it to an ES6 export - and removes other references to `exports` in a few files. This is a breaking change, unfortunately!