### PR TITLE
Don't allow the use of inactive sessions

### DIFF
--- a/lib/permission-filter.ts
+++ b/lib/permission-filter.ts
@@ -189,6 +189,14 @@ export const getSessionActor = async (
 		`Invalid session: ${session}`,
 	);
 
+	// Don't allow inactive sessions to be used
+	assert.USER(
+		context,
+		sessionCard.active,
+		errors.JellyfishInvalidSession,
+		`Invalid session: ${session}`,
+	);
+
 	assert.USER(
 		context,
 		!sessionCard.data.expiration ||

--- a/test/integration/kernel.spec.ts
+++ b/test/integration/kernel.spec.ts
@@ -6734,6 +6734,37 @@ describe('Kernel', () => {
 				},
 			]);
 		});
+
+		it('should throw if the session is not active', async () => {
+			const adminUser = await ctx.kernel.getCardBySlug(
+				ctx.context,
+				ctx.kernel.sessions!.admin,
+				'user-admin@1.0.0',
+			);
+
+			assert(adminUser !== null);
+
+			// Create a new inactive session
+			const session = await ctx.kernel.insertCard(
+				ctx.context,
+				ctx.kernel.sessions!.admin,
+				{
+					slug: ctx.generateRandomSlug({
+						prefix: 'session',
+					}),
+					active: false,
+					type: 'session@1.0.0',
+					version: '1.0.0',
+					data: {
+						actor: adminUser.id,
+					},
+				},
+			);
+
+			expect(
+				ctx.kernel.getCardBySlug(ctx.context, session.id, 'user-admin@1.0.0'),
+			).rejects.toThrow();
+		});
 	});
 
 	describe('.stream()', () => {

--- a/test/integration/permission-filter.spec.ts
+++ b/test/integration/permission-filter.spec.ts
@@ -160,5 +160,44 @@ describe('permission-filter', () => {
 				permissionFilter.getSessionActor(ctx.context, ctx.backend, session.id),
 			).rejects.toThrow(errors.JellyfishSessionExpired);
 		});
+
+		test.only('should throw if the session has been deleted', async () => {
+			const user = await ctx.kernel.insertCard(
+				ctx.context,
+				ctx.kernel.sessions!.admin,
+				{
+					slug: ctx.generateRandomSlug({
+						prefix: 'user',
+					}),
+					type: 'user@1.0.0',
+					version: '1.0.0',
+					data: {
+						email: 'johndoe@example.com',
+						hash: 'PASSWORDLESS',
+						roles: ['foo', 'bar'],
+					},
+				},
+			);
+
+			const session = await ctx.kernel.insertCard(
+				ctx.context,
+				ctx.kernel.sessions!.admin,
+				{
+					slug: ctx.generateRandomSlug({
+						prefix: 'session-delete-test',
+					}),
+					active: false,
+					type: 'session@1.0.0',
+					version: '1.0.0',
+					data: {
+						actor: user.id,
+					},
+				},
+			);
+
+			await expect(
+				permissionFilter.getSessionActor(ctx.context, ctx.backend, session.id),
+			).rejects.toThrow();
+		});
 	});
 });


### PR DESCRIPTION
This change adds an additional check to ensure the session being used is
active.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>