### PR TITLE
Remove .only from permission filter tests

### DIFF
--- a/test/integration/permission-filter.spec.ts
+++ b/test/integration/permission-filter.spec.ts
@@ -161,7 +161,7 @@ describe('permission-filter', () => {
 			).rejects.toThrow(errors.JellyfishSessionExpired);
 		});
 
-		test.only('should throw if the session has been deleted', async () => {
+		test('should throw if the session has been deleted', async () => {
 			const user = await ctx.kernel.insertCard(
 				ctx.context,
 				ctx.kernel.sessions!.admin,


### PR DESCRIPTION
Oops! This was added for debugging a previous patch, but never removed

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>