### PR TITLE
Small tweak to default UI schema

### DIFF
--- a/lib/cards/mixins/ui-schema-defs.json
+++ b/lib/cards/mixins/ui-schema-defs.json
@@ -2,6 +2,9 @@
   "reset": {
     "data": {
       "ui:title": null,
+      "ui:options": {
+        "alignSelf": "stretch"
+      },
       "origin": null,
       "translateDate": null,
       "$$localSchema": null


### PR DESCRIPTION
This change ensures that the `data` element takes up the full width of it's parent element.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>