### PR TITLE
fix handling of escaped json-patch paths

### DIFF
--- a/lib/kernel.ts
+++ b/lib/kernel.ts
@@ -190,7 +190,10 @@ const patchCard = (
 
 		// Only addition can happen on non-existent properties
 		if (operation.op !== 'add') {
-			const path = operation.path.split('/').slice(1);
+			const path = operation.path
+				.split('/')
+				.slice(1)
+				.map(jsonpatch.unescapePathComponent);
 			if (!_.has(card, path)) {
 				// This is a schema mismatch as this case tends
 				// to happen when attempting to violate the

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "unit": "jest lib",
     "integration": "jest test",
     "test": "npm run lint && npm run unit",
+    "compose-test": "docker-compose -f docker-compose.test.yml -f docker-compose.yml up --build --exit-code-from=sut",
     "doc": "typedoc lib/ && touch docs/.nojekyll",
     "prepack": "npm run build",
     "check": "jellycheck"

--- a/test/integration/kernel.spec.ts
+++ b/test/integration/kernel.spec.ts
@@ -195,7 +195,7 @@ describe('Kernel', () => {
 					type: 'card@1.0.0',
 					version: '1.0.0',
 					data: {
-						foo: 'bar',
+						'foo/bla': 'bar',
 						bar: 'baz',
 					},
 				},
@@ -208,7 +208,7 @@ describe('Kernel', () => {
 				[
 					{
 						op: 'remove',
-						path: '/data/foo',
+						path: '/data/foo~1bla',
 					},
 				],
 			);


### PR DESCRIPTION
if a JSON object has a field containing a slash, this needs to be escaped in the patch path. e.g.
```
{ "linux/arm64": true }
"/linux~1arm64"
```
When manually handling those pathes we need to unsure to unescape those terms