### PR TITLE
Fix an issue where the compiler would emit extra statements when querying with nested links

### DIFF
--- a/lib/backend/postgres/jsonschema2sql/sql-query.ts
+++ b/lib/backend/postgres/jsonschema2sql/sql-query.ts
@@ -344,7 +344,7 @@ const linkedToSql = (
 	pushLinkedLateral(
 		data.select,
 		idxStart,
-		state.linkEdges.length,
+		idxStart + 1,
 		nestedLaterals,
 		lateralAlias,
 		data.options,


### PR DESCRIPTION
This issue does not change the result of the query 99% of the time, though it might lead to duplicate results in some very specific cases. This change should also slightly reduce query times for queries with nested links.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>