### PR TITLE
Add @types/json-schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@types/bluebird": "^3.5.36",
     "@types/debounce-promise": "^3.1.4",
     "@types/jest": "^26.0.24",
+    "@types/json-schema": "^7.0.9",
     "@types/pg-format": "^1.0.2",
     "@types/redis": "^2.8.31",
     "@types/redis-mock": "^0.17.0",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Adding `@types/json-schema` as without it `npm run build` fails with:
```
> rimraf build

lib/backend/postgres/jsonschema2sql/sql-query.ts(32,10): error TS2724: '"json-schema"' has no exported member named 'JSONSchema7TypeName'. Did you mean 'JSONSchema4TypeName'?
```