### PR TITLE
Add a generic serialized error contract

### DIFF
--- a/lib/cards/error.ts
+++ b/lib/cards/error.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import type { TypeContractDefinition } from '@balena/jellyfish-types/build/core';
+
+export const error: TypeContractDefinition = {
+	slug: 'error',
+	type: 'type@1.0.0',
+	data: {
+		schema: {
+			type: 'object',
+			properties: {
+				name: {
+					type: 'string',
+				},
+				data: {
+					type: 'object',
+					properties: {
+						message: {
+							type: 'string',
+						},
+						code: {
+							type: 'string',
+						},
+					},
+				},
+			},
+		},
+	},
+};

--- a/lib/cards/index.ts
+++ b/lib/cards/index.ts
@@ -10,6 +10,7 @@ import { action } from './action';
 import { card } from './card';
 import { role } from './role';
 import { org } from './org';
+import { error } from './error';
 import { event } from './event';
 import { link } from './link';
 import { loop } from './loop';
@@ -30,6 +31,7 @@ const cards = [
 	role,
 	org,
 	event,
+	error,
 	link,
 	loop,
 	session,

--- a/lib/kernel.ts
+++ b/lib/kernel.ts
@@ -463,6 +463,7 @@ export class Kernel {
 				CARDS.action,
 				CARDS['action-request'],
 				CARDS.org,
+				CARDS.error,
 				CARDS.event,
 				CARDS.view,
 				CARDS.role,


### PR DESCRIPTION
This is a generic contract for representing errors. The initial use case
for this is to represent errors in the transformer runtime.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>