### PR TITLE
Revert "Revert "Use the new `links2` table in queries""

### DIFF
--- a/lib/backend/postgres/jsonschema2sql/sql-query.ts
+++ b/lib/backend/postgres/jsonschema2sql/sql-query.ts
@@ -179,23 +179,21 @@ const pushLinkedJoins = (
 	cardsTable: string,
 ) => {
 	const linksFilter = new LiteralSql(`
-		(
-			${linked.linksAlias}.name = ${linked.linkName} AND
-			${linked.linksAlias}.fromId = ${parentTable}.id
-		) OR (
-			${linked.linksAlias}.inversename = ${linked.linkName} AND
-			${linked.linksAlias}.toId = ${parentTable}.id
+		${linked.linksAlias}.fromId = ${parentTable}.id AND
+		${linked.linksAlias}.name = (
+			SELECT id
+			FROM strings
+			WHERE string = ${linked.linkName}
 		)
 	`);
-	innerSelect.pushLeftJoin('links', linksFilter, linked.linksAlias);
+	innerSelect.pushLeftJoin('links2', linksFilter, linked.linksAlias);
 	const joinFilter = new LiteralSql(`(
-		(
-			${linked.linksAlias}.name = ${linked.linkName} AND
-			${linked.linksAlias}.toId = ${linked.joinAlias}.id
-		) OR (
-			${linked.linksAlias}.inversename = ${linked.linkName} AND
-			${linked.linksAlias}.fromId = ${linked.joinAlias}.id
-		)
+		${linked.linksAlias}.name = (
+			SELECT id
+			FROM strings
+			WHERE string = ${linked.linkName}
+		) AND
+		${linked.linksAlias}.toId = ${linked.joinAlias}.id
 	) AND (
 		${linked.sqlFilter}
 	)`);


### PR DESCRIPTION
This reverts commit 521ea2f80c70b86971e855647d4be91c6d15c55c.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>