### PR TITLE
get package version without breaking package structure

### DIFF
--- a/lib/backend/postgres/index.ts
+++ b/lib/backend/postgres/index.ts
@@ -38,9 +38,9 @@ import { strict as nativeAssert } from 'assert';
 import type pgPromise = require('pg-promise');
 import { AsyncLocalStorage } from 'async_hooks';
 import * as semver from 'semver';
-import corePackage = require('../../../package.json');
+import getPackageVersion = require('@jsbits/get-package-version');
 
-const coreVersion = corePackage.version;
+const coreVersion = getPackageVersion(__dirname);
 const logger = getLogger('jellyfish-core');
 
 const currentTransaction = new AsyncLocalStorage<Queryable>();

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@balena/jellyfish-environment": "^5.0.3",
     "@balena/jellyfish-logger": "^3.0.69",
     "@balena/jellyfish-metrics": "^1.0.341",
+    "@jsbits/get-package-version": "^1.0.3",
     "bluebird": "^3.7.2",
     "fast-equals": "^2.0.3",
     "fast-json-patch": "^2.2.1",


### PR DESCRIPTION
There are options to do this without an extra dependency ( https://stackoverflow.com/questions/51070138/how-to-import-package-json-into-typescript-file-without-including-it-in-the-comp ) but all involve an unreasonable amount of tsconfig trickery...