### PR TITLE
return kernel-calculated fields on update

### DIFF
--- a/lib/kernel.ts
+++ b/lib/kernel.ts
@@ -825,8 +825,14 @@ export class Kernel {
 				await this.backend.upsertElement(context, patchedFullCard);
 
 				// Otherwise a person that patches a card gets
-				// to see the full card
-				return patchedFilteredCard;
+				// to see the full card, but we also need to get back the stuff, the kernel
+				// update on the root of the card
+				// This will get removed once we get rid of field-level permissions.
+				return {
+					...patchedFilteredCard,
+					created_at: patchedFullCard.created_at,
+					updated_at: patchedFullCard.updated_at,
+				};
 			});
 		});
 


### PR DESCRIPTION
this allows the worker to use this data in subsequent processes like triggers and transformers

I opted for defining the fields explicitly because TS typing got in the way otherwise and it didn't seem worth the complexity, as we know it's exactly these two fields and it's going to be removed "soon"