### PR TITLE
Use correct type version for indexes

### DIFF
--- a/lib/backend/postgres/cards.ts
+++ b/lib/backend/postgres/cards.ts
@@ -660,11 +660,11 @@ export const createTypeIndex = async (
 /**
  * @param {Context} context - session context
  * @param {BackendConnection} connection - database connection
- * @param {String} type - card type name
+ * @param {String} type - type contract versioned slug
  * @param {Array} fields - fields to build indexes for
  *
  * @example
- * const type = 'message'
+ * const type = 'message@1.0.0'
  * const fields = [
  *   {
  *     path: [ 'data', 'payload', 'message' ],
@@ -691,16 +691,14 @@ export const createFullTextSearchIndex = async (
 		),
 		'indexname',
 	);
-	// Create all necessary search indexes for the given type
-	const typeBase = type.split('@')[0];
-	const versionedType = `${typeBase}@1.0.0`;
 
+	// Create all necessary search indexes for the given type.
 	// Similar to the logic, in createTypeIndex, we retry once on failure in case we hit a race condition.
 	try {
 		for (const field of fields) {
 			const path = SqlPath.fromArray(_.clone(field.path));
 			const isJson = path.isProcessingJsonProperty;
-			const name = `${typeBase}__${field.path.join('_')}__search_idx`;
+			const name = `${type.split('@')[0]}__${field.path.join('_')}__search_idx`;
 			if (!indexes.includes(name)) {
 				await utils.createIndex(
 					context,
@@ -712,7 +710,7 @@ export const createFullTextSearchIndex = async (
 						isJson,
 						field.isArray,
 					)})
-						WHERE type=${pgFormat.literal(versionedType)}`,
+						WHERE type=${pgFormat.literal(type)}`,
 				);
 			}
 		}

--- a/lib/backend/postgres/index.ts
+++ b/lib/backend/postgres/index.ts
@@ -337,7 +337,7 @@ const upsertObject = async <T extends Contract = Contract>(
 		if (fullTextSearchFields.length) {
 			await backend.createFullTextSearchIndex(
 				context,
-				insertedObject.slug,
+				`${insertedObject.slug}@${insertedObject.version}`,
 				fullTextSearchFields,
 			);
 		}

--- a/lib/backend/postgres/jsonschema2sql/table-index.spec.ts
+++ b/lib/backend/postgres/jsonschema2sql/table-index.spec.ts
@@ -54,6 +54,7 @@ describe('generateTypeIndexPredicate()', () => {
 		const schema = {
 			slug: 'foobar',
 			type: 'type@1.0.0',
+			version: '1.0.1',
 			data: {
 				schema: {
 					type: 'object',
@@ -72,7 +73,7 @@ describe('generateTypeIndexPredicate()', () => {
 			schema,
 		);
 		expect(predicate).toEqual(
-			`USING btree (name) WHERE type='${schema.slug}@1.0.0'`,
+			`USING btree (name) WHERE type='${schema.slug}@${schema.version}'`,
 		);
 	});
 
@@ -80,6 +81,7 @@ describe('generateTypeIndexPredicate()', () => {
 		const schema = {
 			slug: 'foobar',
 			type: 'type@1.0.0',
+			version: '1.0.1',
 			data: {
 				schema: {
 					type: 'object',
@@ -102,7 +104,7 @@ describe('generateTypeIndexPredicate()', () => {
 			schema,
 		);
 		expect(predicate).toEqual(
-			`USING btree (name,slug) WHERE type='${schema.slug}@1.0.0'`,
+			`USING btree (name,slug) WHERE type='${schema.slug}@${schema.version}'`,
 		);
 	});
 
@@ -110,6 +112,7 @@ describe('generateTypeIndexPredicate()', () => {
 		const schema = {
 			slug: 'foobar',
 			type: 'type@1.0.0',
+			version: '1.0.1',
 			data: {
 				schema: {
 					type: 'object',
@@ -131,7 +134,7 @@ describe('generateTypeIndexPredicate()', () => {
 			schema,
 		);
 		expect(predicate).toEqual(
-			`USING gin (tags) WHERE type='${schema.slug}@1.0.0'`,
+			`USING gin (tags) WHERE type='${schema.slug}@${schema.version}'`,
 		);
 	});
 
@@ -139,6 +142,7 @@ describe('generateTypeIndexPredicate()', () => {
 		const schema = {
 			slug: 'foobar',
 			type: 'type@1.0.0',
+			version: '1.0.1',
 			data: {
 				schema: {
 					type: 'object',
@@ -163,7 +167,7 @@ describe('generateTypeIndexPredicate()', () => {
 			schema,
 		);
 		expect(predicate).toEqual(
-			`USING btree (((data#>>'{"name"}')::text)) WHERE type='${schema.slug}@1.0.0'`,
+			`USING btree (((data#>>'{"name"}')::text)) WHERE type='${schema.slug}@${schema.version}'`,
 		);
 	});
 
@@ -171,6 +175,7 @@ describe('generateTypeIndexPredicate()', () => {
 		const schema = {
 			slug: 'foobar',
 			type: 'type@1.0.0',
+			version: '1.0.1',
 			data: {
 				schema: {
 					type: 'object',
@@ -193,7 +198,7 @@ describe('generateTypeIndexPredicate()', () => {
 			schema,
 		);
 		expect(predicate).toEqual(
-			`USING btree (name,slug) WHERE type='${schema.slug}@1.0.0'`,
+			`USING btree (name,slug) WHERE type='${schema.slug}@${schema.version}'`,
 		);
 	});
 
@@ -201,6 +206,7 @@ describe('generateTypeIndexPredicate()', () => {
 		const schema = {
 			slug: 'foobar',
 			type: 'type@1.0.0',
+			version: '1.0.1',
 			data: {
 				schema: {
 					type: 'object',
@@ -228,7 +234,7 @@ describe('generateTypeIndexPredicate()', () => {
 			schema,
 		);
 		expect(predicate).toEqual(
-			`USING gin ((data#>'{"tags"}')) WHERE type='${schema.slug}@1.0.0'`,
+			`USING gin ((data#>'{"tags"}')) WHERE type='${schema.slug}@${schema.version}'`,
 		);
 	});
 });

--- a/lib/backend/postgres/jsonschema2sql/table-index.ts
+++ b/lib/backend/postgres/jsonschema2sql/table-index.ts
@@ -43,7 +43,7 @@ export function generateTypeIndexPredicate(
 	fields: string[],
 	schema: core.ContractDefinition<any>,
 ): string {
-	const type = schema.slug;
+	const type = `${schema.slug}@${schema.version}`;
 	const columns = [];
 	let indexType = 'btree';
 	let asText = true;


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Use actual type version when creating indexes instead of (dangerously) assuming `1.0.0`.