### PR TITLE
Add the `user-settings` and `authentication` types

### DIFF
--- a/lib/cards/authentication.ts
+++ b/lib/cards/authentication.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+export const authentication = {
+	slug: 'authentication',
+	type: 'type@1.0.0',
+	name: 'Authentication Details',
+	data: {
+		schema: {
+			type: 'object',
+			properties: {
+				slug: {
+					type: 'string',
+					pattern: '^authentication-[a-z0-9-]+$',
+				},
+				data: {
+					type: 'object',
+					properties: {
+						hash: {
+							type: 'string',
+							minLength: 1,
+						},
+						oauth: {
+							description: 'Linked accounts',
+							type: 'object',
+						},
+					},
+				},
+			},
+		},
+	},
+};

--- a/lib/cards/index.ts
+++ b/lib/cards/index.ts
@@ -23,6 +23,8 @@ import { view } from './view';
 import { oauthProvider } from './oauth-provider';
 import { oauthClient } from './oauth-client';
 import { scheduledAction } from './scheduled-action';
+import { authentication } from './authentication';
+import { userSettings } from './user-settings';
 import { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 const cards = [
@@ -44,6 +46,8 @@ const cards = [
 	oauthProvider,
 	oauthClient,
 	scheduledAction,
+	authentication,
+	userSettings,
 ];
 
 export const CARDS = cards.reduce<{ [slug: string]: ContractDefinition }>(

--- a/lib/cards/user-settings.ts
+++ b/lib/cards/user-settings.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+export const userSettings = {
+	slug: 'user-settings',
+	type: 'type@1.0.0',
+	name: 'User Settings',
+	data: {
+		schema: {
+			type: 'object',
+			properties: {
+				slug: {
+					type: 'string',
+					pattern: '^user-settings-[a-z0-9-]+$',
+				},
+				data: {
+					type: 'object',
+					properties: {
+						type: {
+							type: 'string',
+						},
+						homeView: {
+							description: 'The default view that is loaded after you login',
+							type: 'string',
+							format: 'uuid',
+						},
+						activeLoop: {
+							// TODO: Add pattern regex once it is finalized
+							description: 'The loop that the user is currently working on',
+							type: ['string', 'null'],
+						},
+						sendCommand: {
+							title: 'Send command',
+							description: 'Command to send a message',
+							type: 'string',
+							default: 'shift+enter',
+							enum: ['shift+enter', 'ctrl+enter', 'enter'],
+						},
+						disableNotificationSound: {
+							title: 'Disable notification sound',
+							description: 'Do not play a sound when displaying notifications',
+							type: 'boolean',
+							default: false,
+						},
+						starredViews: {
+							description: 'List of view slugs that are starred',
+							type: 'array',
+							items: {
+								type: 'string',
+							},
+						},
+						viewSettings: {
+							description:
+								'A map of settings for view cards, keyed by the view id',
+							type: 'object',
+							patternProperties: {
+								'^.*$': {
+									lens: {
+										type: 'string',
+									},
+									slice: {
+										type: 'string',
+									},
+									notifications: {
+										type: 'object',
+										properties: {
+											web: {
+												title: 'Web',
+												description: 'Alert me with desktop notifications',
+												type: 'object',
+												properties: {
+													update: {
+														type: 'boolean',
+													},
+													mention: {
+														type: 'boolean',
+													},
+													alert: {
+														type: 'boolean',
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+};

--- a/lib/kernel.ts
+++ b/lib/kernel.ts
@@ -418,7 +418,9 @@ export class Kernel {
 		await Promise.all([
 			unsafeUpsert(CARDS.type),
 			unsafeUpsert(CARDS.session),
+			unsafeUpsert(CARDS.authentication),
 			unsafeUpsert(CARDS.user),
+			unsafeUpsert(CARDS['user-settings']),
 			unsafeUpsert(CARDS['role-user-admin']),
 		]);
 

--- a/test/integration/backend/index.spec.ts
+++ b/test/integration/backend/index.spec.ts
@@ -3057,6 +3057,9 @@ describe('backend', () => {
 					},
 				},
 			);
+			for (const x of results2) {
+				x.linked_at = {};
+			}
 
 			const results3 = await ctx.backend.query(
 				ctx.context,

--- a/test/integration/kernel.spec.ts
+++ b/test/integration/kernel.spec.ts
@@ -529,6 +529,9 @@ describe('Kernel', () => {
 				ctx.kernel.sessions!.admin,
 				`${card.slug}@${card.version}`,
 			);
+			if (result !== null) {
+				result.linked_at = card.linked_at;
+			}
 
 			expect(result).toEqual(card);
 		});
@@ -724,6 +727,9 @@ describe('Kernel', () => {
 				ctx.kernel.sessions!.admin,
 				`${userCard.slug}@${userCard.version}`,
 			);
+			if (result !== null) {
+				result.linked_at = userCard.linked_at;
+			}
 
 			expect(result).toEqual(userCard);
 		});
@@ -839,6 +845,9 @@ describe('Kernel', () => {
 				ctx.kernel.sessions!.admin,
 				`${userCard.slug}@${userCard.version}`,
 			);
+			if (result !== null) {
+				result.linked_at = userCard.linked_at;
+			}
 
 			expect(result).toEqual(userCard);
 		});
@@ -1193,6 +1202,9 @@ describe('Kernel', () => {
 				ctx.kernel.sessions!.admin,
 				`${userCard.slug}@${userCard.version}`,
 			);
+			if (result !== null) {
+				result.linked_at = userCard.linked_at;
+			}
 
 			expect(result).toEqual(userCard);
 		});
@@ -1307,6 +1319,9 @@ describe('Kernel', () => {
 				ctx.kernel.sessions!.admin,
 				`${userCard.slug}@${userCard.version}`,
 			);
+			if (result !== null) {
+				result.linked_at = userCard.linked_at;
+			}
 
 			expect(result).toEqual(userCard);
 		});
@@ -3640,7 +3655,7 @@ describe('Kernel', () => {
 				},
 			});
 
-			const results = await ctx.kernel.query(ctx.context, session.id, {
+			let results = await ctx.kernel.query(ctx.context, session.id, {
 				type: 'object',
 				required: ['type', 'slug', 'active', 'data'],
 				additionalProperties: false,
@@ -3660,6 +3675,7 @@ describe('Kernel', () => {
 					},
 				},
 			});
+			results = results.filter((x) => x.slug !== 'user-settings');
 
 			expect(results).toEqual([
 				_.pick(await CARDS.user, ['type', 'slug', 'active', 'data']),
@@ -3831,7 +3847,7 @@ describe('Kernel', () => {
 				},
 			});
 
-			const results = await ctx.kernel.query(ctx.context, session.id, {
+			let results = await ctx.kernel.query(ctx.context, session.id, {
 				type: 'object',
 				properties: {
 					id: {
@@ -3846,6 +3862,7 @@ describe('Kernel', () => {
 					},
 				},
 			});
+			results = results.filter((x) => x.slug !== 'user-settings');
 
 			expect(results).toEqual([
 				{
@@ -3902,7 +3919,7 @@ describe('Kernel', () => {
 				},
 			});
 
-			const results = await ctx.kernel.query(ctx.context, session.id, {
+			let results = await ctx.kernel.query(ctx.context, session.id, {
 				type: 'object',
 				additionalProperties: true,
 				properties: {
@@ -3918,6 +3935,7 @@ describe('Kernel', () => {
 					},
 				},
 			});
+			results = results.filter((x) => x.slug !== 'user-settings');
 
 			expect(results).toEqual([
 				{
@@ -3972,7 +3990,7 @@ describe('Kernel', () => {
 				},
 			});
 
-			const results = await ctx.kernel.query(ctx.context, session.id, {
+			let results = await ctx.kernel.query(ctx.context, session.id, {
 				type: 'object',
 				additionalProperties: true,
 				properties: {
@@ -3988,6 +4006,7 @@ describe('Kernel', () => {
 					},
 				},
 			});
+			results = results.filter((x) => x.slug !== 'user-settings');
 
 			expect(results).toEqual([
 				{


### PR DESCRIPTION
This is the first step in preparation for a refactor on how JF handles permissions. These two new types are automatically updated when `user` contracts are updated.

JIP: https://jel.ly.fish/improvement-jip-remove-field-level-permissions-8d561c94-2d33-4026-829c-272600018558
Change-type: minor
Signed-off-by: Carol Schulze <carol@balena.io>