### PR TITLE
Rationalize the use of a "context"

### DIFF
--- a/lib/backend/postgres/cards.spec.ts
+++ b/lib/backend/postgres/cards.spec.ts
@@ -1,10 +1,9 @@
 import * as errors from '../../errors';
 import * as cards from './cards';
+import { Context } from '../../context';
 import { v4 as uuid } from 'uuid';
 
-const TEST_CONTEXT = {
-	id: `UNIT-TEST-${uuid()}`,
-};
+const TEST_CONTEXT = new Context({ id: `UNIT-TEST-${uuid()}` });
 
 describe('cards', () => {
 	describe('.fromTypePath()', () => {

--- a/lib/backend/postgres/jsonschema2sql/index.spec.ts
+++ b/lib/backend/postgres/jsonschema2sql/index.spec.ts
@@ -1,3 +1,4 @@
+import { Context } from '../../../context';
 import { JSONSchema } from '@balena/jellyfish-types';
 import * as jsonschema2sql from './index';
 
@@ -28,7 +29,13 @@ describe('jsonschema2sql', () => {
 				limit: 1,
 			};
 
-			const sql = jsonschema2sql.compile('cards', {}, query, options);
+			const sql = jsonschema2sql.compile(
+				new Context(null),
+				'cards',
+				{},
+				query,
+				options,
+			);
 			expect(sql.includes('to_tsvector')).toBe(true);
 			expect(sql.includes('to_tsquery')).toBe(true);
 		});

--- a/lib/backend/postgres/jsonschema2sql/index.ts
+++ b/lib/backend/postgres/jsonschema2sql/index.ts
@@ -1,16 +1,19 @@
 import { JSONSchema } from '@balena/jellyfish-types';
 import * as _ from 'lodash';
+import { Context } from '../../../context';
 import { SqlQueryOptions } from '../types';
 import { SelectMap } from './select-map';
 import { SqlQuery } from './sql-query';
 
 export const compile = (
+	context: Context,
 	table: string,
 	select: any,
 	schema: JSONSchema,
 	options: SqlQueryOptions = {},
 ) => {
 	return SqlQuery.fromSchema(
+		context,
 		null,
 		new SelectMap(select),
 		schema,

--- a/lib/backend/postgres/links.ts
+++ b/lib/backend/postgres/links.ts
@@ -1,16 +1,11 @@
 import * as _ from 'lodash';
-import { getLogger } from '@balena/jellyfish-logger';
-import {
-	Context,
-	Contract,
-	LinkContract,
-} from '@balena/jellyfish-types/build/core';
+import { Contract, LinkContract } from '@balena/jellyfish-types/build/core';
+import { Context } from '../../context';
 import { Queryable } from './types';
 import { PostgresBackend } from '.';
 
 // tslint:disable-next-line: no-var-requires
 const { version: coreVersion } = require('../../../package.json');
-const logger = getLogger('jellyfish-core');
 
 const LINK_ORIGIN_PROPERTY = '$link';
 const LINK_TABLE = 'links2';
@@ -26,7 +21,7 @@ export const setup = async (
 		cards: string;
 	},
 ) => {
-	logger.debug(context, 'Creating links table', {
+	context.debug('Creating links table', {
 		table: LINK_TABLE,
 		database,
 	});

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,0 +1,101 @@
+import * as assert from '@balena/jellyfish-assert';
+import {
+	AssertExpression,
+	AssertMessage,
+	AssertErrorConstructor,
+} from '@balena/jellyfish-assert';
+import * as logger from '@balena/jellyfish-logger';
+import { LogContext } from '@balena/jellyfish-logger';
+
+const LOGGER = logger.getLogger('jellyfish-core');
+
+/**
+ * Union type useful when a function can accept either a `Context` object or
+ * a raw `LogContext`.
+ */
+export type MixedContext = Context | LogContext;
+
+/**
+ * Context object encapsulating the current log context.
+ */
+export class Context {
+	/**
+	 * Constructor.
+	 */
+	constructor(private logContext: LogContext) {}
+
+	/**
+	 * Build a `Context` from a `MixedContext`.
+	 */
+	static fromMixed(mixedContext: MixedContext): Context {
+		if (mixedContext instanceof Context) {
+			return mixedContext;
+		}
+
+		return new Context(mixedContext);
+	}
+
+	/**
+	 * Get the wrapped log context.
+	 */
+	getLogContext(): LogContext {
+		return this.logContext;
+	}
+
+	/**
+	 * Log a debug message.
+	 */
+	debug(message: string, data?: object) {
+		LOGGER.debug(this.logContext, message, data);
+	}
+
+	/**
+	 * Log an informational message.
+	 */
+	info(message: string, data?: object) {
+		LOGGER.info(this.logContext, message, data);
+	}
+
+	/**
+	 * Log a warning message.
+	 */
+	warn(message: string, data?: object) {
+		LOGGER.warn(this.logContext, message, data);
+	}
+
+	/**
+	 * Log an error message.
+	 */
+	error(message: string, data?: object) {
+		LOGGER.error(this.logContext, message, data);
+	}
+
+	/**
+	 * Log an exception.
+	 */
+	exception(message: string, data: Error) {
+		LOGGER.exception(this.logContext, message, data);
+	}
+
+	/**
+	 * Assert an expression.
+	 */
+	assertInternal(
+		expression: AssertExpression,
+		error: AssertErrorConstructor,
+		message: AssertMessage,
+	) {
+		assert.INTERNAL(this.logContext, expression, error, message);
+	}
+
+	/**
+	 * Assert an expression.
+	 */
+	assertUser(
+		expression: AssertExpression,
+		error: AssertErrorConstructor,
+		message: AssertMessage,
+	) {
+		assert.USER(this.logContext, expression, error, message);
+	}
+}

--- a/lib/permission-filter.ts
+++ b/lib/permission-filter.ts
@@ -1,10 +1,10 @@
 import jsone = require('json-e');
 import * as _ from 'lodash';
-import * as assert from '@balena/jellyfish-assert';
+import { Context } from './context';
 import jsonSchema from './json-schema';
 import * as errors from './errors';
 import { CARDS } from './cards';
-import { Context, Contract } from '@balena/jellyfish-types/build/core';
+import { Contract } from '@balena/jellyfish-types/build/core';
 import { DatabaseBackend } from './backend/postgres/types';
 import { JSONSchema } from '@balena/jellyfish-types';
 
@@ -171,23 +171,20 @@ export const getSessionActor = async (
 ) => {
 	const sessionCard = await backend.getElementById(context, session);
 
-	assert.USER(
-		context,
+	context.assertUser(
 		sessionCard,
 		errors.JellyfishInvalidSession,
 		`Invalid session: ${session}`,
 	);
 
 	// Don't allow inactive sessions to be used
-	assert.USER(
-		context,
+	context.assertUser(
 		sessionCard.active,
 		errors.JellyfishInvalidSession,
 		`Invalid session: ${session}`,
 	);
 
-	assert.USER(
-		context,
+	context.assertUser(
 		!sessionCard.data.expiration ||
 			new Date() <= new Date(sessionCard.data.expiration),
 		errors.JellyfishSessionExpired,
@@ -196,8 +193,7 @@ export const getSessionActor = async (
 
 	const actor = await backend.getElementById(context, sessionCard.data.actor);
 
-	assert.INTERNAL(
-		context,
+	context.assertInternal(
 		actor,
 		errors.JellyfishNoElement,
 		`Invalid actor: ${sessionCard.data.actor}`,

--- a/test/integration/backend/helpers.ts
+++ b/test/integration/backend/helpers.ts
@@ -3,7 +3,7 @@ import { backend as Backend } from '../../../lib/backend';
 import { defaultEnvironment as environment } from '@balena/jellyfish-environment';
 import { Cache } from '../../../lib/cache';
 import * as errors from '../../../lib/errors';
-import { Context } from '@balena/jellyfish-types/build/core';
+import { Context } from '../../../lib/context';
 import { DatabaseBackend } from '../../../lib/backend/postgres/types';
 
 export interface BackendContext {
@@ -42,11 +42,7 @@ export const before = async (
 		} as any),
 	);
 
-	const context = {
-		id: `CORE-TEST-${uuid()}`,
-	};
-
-	ctx.context = context;
+	ctx.context = new Context({ id: `CORE-TEST-${uuid()}` });
 
 	if (ctx.cache) {
 		await ctx.cache.connect();

--- a/test/integration/backend/postgres/index.spec.ts
+++ b/test/integration/backend/postgres/index.spec.ts
@@ -3,6 +3,7 @@ import { v4 as uuid } from 'uuid';
 import * as helpers from '../helpers';
 import { version as packageVersion } from '../../../../package.json';
 import { INDEX_TABLE, PostgresBackend } from '../../../../lib/backend/postgres';
+import { Context } from '../../../../lib/context';
 
 let ctx: helpers.BackendContext;
 
@@ -49,9 +50,7 @@ describe('Setup', () => {
 						database: dbName,
 					}),
 				);
-				return backend.connect({
-					id: `CORE-DB-TEST-${uuid()}`,
-				});
+				return backend.connect(new Context({ id: `CORE-DB-TEST-${uuid()}` }));
 			};
 			const result = await Promise.all([
 				makeBackend(),
@@ -101,9 +100,7 @@ describe('Setup', () => {
 						database: dbName,
 					}),
 				);
-				await backend.connect({
-					id: `CORE-DB-TEST-${uuid()}`,
-				});
+				await backend.connect(new Context({ id: `CORE-DB-TEST-${uuid()}` }));
 
 				return backend;
 			};
@@ -145,9 +142,7 @@ describe('Setup', () => {
 						database: dbName,
 					}),
 				);
-				await backend.connect({
-					id: `CORE-DB-TEST-${uuid()}`,
-				});
+				await backend.connect(new Context({ id: `CORE-DB-TEST-${uuid()}` }));
 
 				return backend;
 			};

--- a/test/integration/backend/postgres/jsonschema2sql/index.spec.ts
+++ b/test/integration/backend/postgres/jsonschema2sql/index.spec.ts
@@ -6,6 +6,7 @@ import { defaultEnvironment as environment } from '@balena/jellyfish-environment
 import * as jsonschema2sql from '../../../../../lib/backend/postgres/jsonschema2sql';
 import * as cards from '../../../../../lib/backend/postgres/cards';
 import * as links from '../../../../../lib/backend/postgres/links';
+import { Context } from '../../../../../lib/context';
 import regexpTestSuite from './regexp';
 import formatMaxMinTestSuite from './format-max-min';
 import { Contract } from '@balena/jellyfish-types/build/core';
@@ -72,9 +73,7 @@ const SUPPORTED_SUITES = [
 	'formatMaximum|formatMinimum',
 ];
 
-const context = {
-	id: 'jsonschema2sql-test',
-};
+const context = new Context({ id: 'jsonschema2sql-test' });
 
 interface RunnerOptions {
 	backend: typeof ctx['backend'];
@@ -138,7 +137,7 @@ const runner = async ({
 	/*
 	 * 3. Query the elements back using our translator.
 	 */
-	const query = jsonschema2sql.compile(table, {}, schema, options);
+	const query = jsonschema2sql.compile(context, table, {}, schema, options);
 
 	/*
 	 * 4. Return the results.

--- a/test/integration/backend/postgres/streams/index.spec.ts
+++ b/test/integration/backend/postgres/streams/index.spec.ts
@@ -5,7 +5,7 @@ import pgp from '../../../../../lib/backend/postgres/pg-promise';
 import * as streams from '../../../../../lib/backend/postgres/streams';
 import { defaultEnvironment as environment } from '@balena/jellyfish-environment';
 import { PostgresBackend } from '../../../../../lib/backend/postgres/index';
-import { Context } from '@balena/jellyfish-types/build/core';
+import { Context } from '../../../../../lib/context';
 import { DatabaseConnection } from '../../../../../lib/backend/postgres/types';
 
 let ctx: {
@@ -31,9 +31,7 @@ beforeEach(async () => {
 	const id = uuid();
 	const database = `test_streams_${id.replace(/-/g, '')}`;
 
-	const context = {
-		id: `TEST-STREAMS-${id}`,
-	};
+	const context = new Context({ id: `TEST-STREAMS-${id}` });
 
 	const table = 'test_table';
 


### PR DESCRIPTION
Currently, many functions take an argument called `context`. This is simply an arbitrary object that should be passed as first argument to calls into the logging or assert libraries. This commit introduces a `Context` class that encapsulates the logging context. It also exposes logging and assert functions so that, for example, calls like `logger.info(context, ...` are replaced by `context.info(...`.

In the future the `Context` class will carry more than just the log context.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>