### PR TITLE
Restrict usage of `jellyfish-types` to only `JSONSchema` and the contract types

### DIFF
--- a/lib/backend/postgres/cards.ts
+++ b/lib/backend/postgres/cards.ts
@@ -13,7 +13,8 @@ import { generateTypeIndexPredicate } from './jsonschema2sql/table-index';
 import { DatabaseBackend, SearchFieldDef, Queryable } from './types';
 import { Contract } from '@balena/jellyfish-types/build/core';
 import { TypedError } from 'typed-error';
-import { core, JSONSchema } from '@balena/jellyfish-types';
+import { JSONSchema } from '@balena/jellyfish-types';
+import { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 // tslint:disable-next-line: no-var-requires
 const { version: coreVersion } = require('../../../package.json');
@@ -584,7 +585,7 @@ export const createTypeIndex = async (
 	context: Context,
 	connection: PostgresBackend,
 	fields: string[],
-	schema: core.ContractDefinition<any>,
+	schema: ContractDefinition<any>,
 	retries: number = 1,
 ): Promise<void> => {
 	/*

--- a/lib/backend/postgres/index.ts
+++ b/lib/backend/postgres/index.ts
@@ -11,7 +11,8 @@ import * as cards from './cards';
 import * as streams from './streams';
 import * as utils from './utils';
 import pgp from './pg-promise';
-import { core, JSONSchema } from '@balena/jellyfish-types';
+import { JSONSchema } from '@balena/jellyfish-types';
+import { ContractDefinition } from '@balena/jellyfish-types/build/core';
 import { Contract, LinkContract } from '@balena/jellyfish-types/build/core';
 import {
 	BackendQueryOptions,
@@ -1305,7 +1306,7 @@ export class PostgresBackend implements Queryable {
 	async createTypeIndex(
 		context: Context,
 		fields: string[],
-		schema: core.ContractDefinition<any>,
+		schema: ContractDefinition<any>,
 	) {
 		await cards.createTypeIndex(context, this, fields, schema);
 	}

--- a/lib/backend/postgres/jsonschema2sql/errors.ts
+++ b/lib/backend/postgres/jsonschema2sql/errors.ts
@@ -1,5 +1,5 @@
 import { TypedError } from 'typed-error';
-import { JellyfishError } from '@balena/jellyfish-types';
+import { JellyfishError } from '../../../errors';
 
 export class BaseTypedError extends TypedError implements JellyfishError {
 	expected: boolean = false;

--- a/lib/backend/postgres/jsonschema2sql/table-index.ts
+++ b/lib/backend/postgres/jsonschema2sql/table-index.ts
@@ -1,4 +1,4 @@
-import { core } from '@balena/jellyfish-types';
+import { ContractDefinition } from '@balena/jellyfish-types/build/core';
 import * as _ from 'lodash';
 import * as pgFormat from 'pg-format';
 import { SqlPath } from './sql-path';
@@ -12,7 +12,7 @@ import { SqlPath } from './sql-path';
  * isArrayField({...}, 'data.payload.message');
  */
 export function isArrayField(
-	schema: core.ContractDefinition<any>,
+	schema: ContractDefinition<any>,
 	fieldPath: string,
 ): boolean {
 	const fullPath = ['data', 'schema', 'properties'].concat(
@@ -35,7 +35,7 @@ export function isArrayField(
  */
 export function generateTypeIndexPredicate(
 	fields: string[],
-	schema: core.ContractDefinition<any>,
+	schema: ContractDefinition<any>,
 ): string {
 	const type = `${schema.slug}@${schema.version}`;
 	const columns = [];

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,5 +1,14 @@
 import { TypedError } from 'typed-error';
-import { JellyfishError } from '@balena/jellyfish-types';
+
+export interface JellyfishError extends Error {
+	/**
+	 * True if the error could be expected in normal circumstances.
+	 *
+	 * i.e. if expected is true, this error isn't a result of a bug
+	 * or an out-of-memory or segmentation-fault error etc.
+	 */
+	expected: boolean;
+}
 
 export class BaseTypedError extends TypedError implements JellyfishError {
 	expected: boolean = false;

--- a/test/integration/backend/index.spec.ts
+++ b/test/integration/backend/index.spec.ts
@@ -1,9 +1,10 @@
 import * as _ from 'lodash';
 import * as Bluebird from 'bluebird';
 import * as errors from '../../../lib/errors';
+import { Stream } from '../../../lib/backend/postgres/streams';
 import * as helpers from './helpers';
 import { JSONSchema } from '@balena/jellyfish-types';
-import { Contract, Stream } from '@balena/jellyfish-types/build/core';
+import { Contract } from '@balena/jellyfish-types/build/core';
 
 let ctx: helpers.BackendContext;
 

--- a/test/integration/kernel.spec.ts
+++ b/test/integration/kernel.spec.ts
@@ -3,9 +3,10 @@ import * as Bluebird from 'bluebird';
 import { v4 as uuid } from 'uuid';
 import * as errors from '../../lib/errors';
 import { CARDS } from '../../lib/cards';
+import { Stream } from '../../lib/backend/postgres/streams';
 import * as helpers from './helpers';
 import { once } from 'events';
-import { Contract, Stream } from '@balena/jellyfish-types/build/core';
+import { Contract } from '@balena/jellyfish-types/build/core';
 import { JSONSchema } from '@balena/jellyfish-types';
 import { strict as assert } from 'assert';
 


### PR DESCRIPTION
Connects-to: https://github.com/product-os/jellyfish-types/issues/336
Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>