### PR TITLE
More interface fixes

### DIFF
--- a/lib/backend/index.ts
+++ b/lib/backend/index.ts
@@ -1,5 +1,5 @@
 import { defaultEnvironment as environment } from '@balena/jellyfish-environment';
-import { PostgresBackend } from './postgres';
+import { PostgresBackend, PostgresBackendOptions } from './postgres';
 
 const backends = {
 	postgres: PostgresBackend,
@@ -7,3 +7,5 @@ const backends = {
 
 export const backend =
 	backends[environment.database.type as keyof typeof backends];
+
+export { PostgresBackendOptions };

--- a/lib/backend/postgres/index.ts
+++ b/lib/backend/postgres/index.ts
@@ -451,7 +451,7 @@ const upsertObject = async <T extends Contract = Contract>(
 	return insertedObject;
 };
 
-interface PostgresBackendOptions {
+export interface PostgresBackendOptions {
 	database: string;
 	connectRetryDelay?: number;
 	user: string;
@@ -492,7 +492,7 @@ const defaultPgOptions: Partial<PostgresBackendOptions> = {
  * class.
  */
 export class PostgresBackend implements Queryable {
-	private connection?: DatabaseConnection | null;
+	public connection?: DatabaseConnection | null;
 	options: PostgresBackendOptions;
 	database: string;
 	connectRetryDelay: number;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,19 +1,28 @@
-import { Kernel as CoreKernel } from './kernel';
-import { backend as CoreBackend } from './backend';
-import { Cache } from './cache';
-import * as coreErrors from './errors';
+import { LogContext } from '@balena/jellyfish-logger';
+import { Cache as MemoryCache } from './cache';
 import { CARDS } from './cards';
+import { backend as CoreBackend, PostgresBackendOptions } from './backend';
+import * as coreErrors from './errors';
+import { Kernel as CoreKernel } from './kernel';
 
 export * as cardMixins from './cards/mixins';
-// TODO: why would external modules need to access the `BackendObject`?
-export { CoreBackend, CoreKernel, coreErrors };
+export {
+	CoreBackend,
+	coreErrors,
+	CoreKernel,
+	MemoryCache,
+	PostgresBackendOptions,
+};
 
-export const MemoryCache = Cache;
 export const cards = CARDS;
 
-export const create = async (context: any, cache: any, options: any) => {
-	const backend = new CoreBackend(cache, coreErrors, options.backend);
+export const create = async (
+	logContext: LogContext,
+	cache: MemoryCache | null,
+	options: PostgresBackendOptions,
+) => {
+	const backend = new CoreBackend(cache, coreErrors, options);
 	const kernel = new CoreKernel(backend);
-	await kernel.initialize(context);
+	await kernel.initialize(logContext);
 	return kernel;
 };


### PR DESCRIPTION
- Put proper types in the exported `create` function instead of `any`s.
- Properly export the `Cache` type.
- Export `PostgresBackendOptions`.
- Temporarely make `CoreBackend.connection` public because the queue requires access to it.

Change-type: major
Signed-off-by: Carol Schulze <carol@balena.io>