### PR TITLE
Use `TRUNCATE` instead of `DELETE FROM` when resetting the database

### DIFF
--- a/lib/backend/postgres/index.ts
+++ b/lib/backend/postgres/index.ts
@@ -791,8 +791,8 @@ export class PostgresBackend implements Queryable {
 		context.debug('Resetting database', { database: this.database });
 
 		await this.any(`
-			DELETE FROM ${links.TABLE};
-			DELETE FROM ${cards.TABLE};
+			TRUNCATE ${links.TABLE};
+			TRUNCATE ${cards.TABLE};
 		`);
 	}
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>