### PR TITLE
Require id in action-request context

### DIFF
--- a/lib/cards/action-request.ts
+++ b/lib/cards/action-request.ts
@@ -26,6 +26,12 @@ export const actionRequest = {
 						},
 						context: {
 							type: 'object',
+							required: ['id'],
+							properties: {
+								id: {
+									type: 'string',
+								},
+							},
 						},
 						originator: {
 							type: 'string',


### PR DESCRIPTION
Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>

---

Require `id` in `action-request.context` objects to make it compatible with the `LogContext` type.