### PR TITLE
Fix Postgres reset statement

### DIFF
--- a/lib/backend/postgres/index.ts
+++ b/lib/backend/postgres/index.ts
@@ -794,10 +794,7 @@ export class PostgresBackend implements Queryable {
 	async reset(context: Context) {
 		context.debug('Resetting database', { database: this.database });
 
-		await this.any(`
-			TRUNCATE ${links.TABLE};
-			TRUNCATE ${cards.TABLE};
-		`);
+		await this.any(`TRUNCATE ${links.TABLE}, ${cards.TABLE};`);
 	}
 
 	/*


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Currently, calling `reset()` results in the following Postgres errors:
```
postgres_1  | 2022-01-06 02:57:00.407 UTC [4866] ERROR:  cannot truncate a table referenced in a foreign key constraint
postgres_1  | 2022-01-06 02:57:00.407 UTC [4866] DETAIL:  Table "links2" references "cards".
postgres_1  | 2022-01-06 02:57:00.407 UTC [4866] HINT:  Truncate table "links2" at the same time, or use TRUNCATE ... CASCADE.
```