### PR TITLE
Restrict guest user role

### DIFF
--- a/lib/contracts/role-user-guest.ts
+++ b/lib/contracts/role-user-guest.ts
@@ -8,190 +8,20 @@ export const roleUserGuest: RoleContractDefinition = {
 	data: {
 		read: {
 			type: 'object',
-			required: ['active'],
+			required: ['slug', 'type'],
+			additionalProperties: true,
 			properties: {
-				active: {
-					type: 'boolean',
-					const: true,
+				slug: {
+					type: 'string',
+					const: {
+						$eval: 'user.slug',
+					},
 				},
 				type: {
-					not: {
-						enum: ['authentication@1.0.0', 'user-settings@1.0.0'],
-					},
+					type: 'string',
+					const: 'user@1.0.0',
 				},
 			},
-			anyOf: [
-				{
-					type: 'object',
-					required: ['slug', 'type', 'data'],
-					properties: {
-						slug: {
-							type: 'string',
-							enum: [
-								'execute',
-								'link',
-								'user',
-								'card',
-								'action',
-								'create',
-								'update',
-								'session',
-							],
-						},
-						type: {
-							type: 'string',
-							const: 'type@1.0.0',
-						},
-						data: {
-							type: 'object',
-							additionalProperties: true,
-						},
-					},
-				},
-				{
-					type: 'object',
-					required: ['id', 'type', 'data'],
-					properties: {
-						id: {
-							type: 'string',
-						},
-						type: {
-							type: 'string',
-							enum: ['create@1.0.0', 'update@1.0.0'],
-						},
-						data: {
-							type: 'object',
-							required: ['timestamp', 'target', 'actor', 'payload'],
-							properties: {
-								timestamp: {
-									type: 'string',
-								},
-								target: {
-									type: 'string',
-								},
-								actor: {
-									type: 'string',
-									const: {
-										$eval: 'user.id',
-									},
-								},
-								payload: {
-									type: 'object',
-								},
-							},
-						},
-					},
-				},
-				{
-					type: 'object',
-					required: ['type', 'data'],
-					additionalProperties: true,
-					properties: {
-						type: {
-							type: 'string',
-							const: 'link@1.0.0',
-						},
-						data: {
-							type: 'object',
-							additionalProperties: true,
-						},
-					},
-				},
-				{
-					type: 'object',
-					required: ['id', 'slug', 'type', 'data'],
-					properties: {
-						id: {
-							type: 'string',
-						},
-						slug: {
-							type: 'string',
-							enum: [
-								'action-create-session',
-								'action-update-card',
-								'action-upsert-card',
-								'action-create-event',
-								'action-oauth-authorize',
-								'action-request-password-reset',
-								'action-complete-password-reset',
-								'action-complete-first-time-login',
-							],
-						},
-						type: {
-							type: 'string',
-							const: 'action@1.0.0',
-						},
-						data: {
-							type: 'object',
-							additionalProperties: true,
-						},
-					},
-				},
-				{
-					type: 'object',
-					required: ['type', 'data'],
-					additionalProperties: true,
-					properties: {
-						type: {
-							type: 'string',
-							enum: ['execute@1.0.0', 'session@1.0.0'],
-						},
-						data: {
-							type: 'object',
-							additionalProperties: true,
-							required: ['actor'],
-							properties: {
-								actor: {
-									type: 'string',
-									const: {
-										$eval: 'user.id',
-									},
-								},
-							},
-						},
-					},
-				},
-				{
-					type: 'object',
-					required: ['slug', 'type'],
-					additionalProperties: true,
-					properties: {
-						slug: {
-							type: 'string',
-							const: {
-								$eval: 'user.slug',
-							},
-						},
-						type: {
-							type: 'string',
-							const: 'user@1.0.0',
-						},
-					},
-				},
-				{
-					type: 'object',
-					required: ['id', 'type', 'slug', 'version'],
-					additionalProperties: false,
-					properties: {
-						id: {
-							type: 'string',
-						},
-						type: {
-							type: 'string',
-							const: 'user@1.0.0',
-						},
-						slug: {
-							type: 'string',
-							not: {
-								const: 'user-admin',
-							},
-						},
-						version: {
-							type: 'string',
-						},
-					},
-				},
-			],
 		},
 	},
 };


### PR DESCRIPTION
This changes the guest user role so that it can only view the guest user
contract. This change goes hand-in-hand with updates to the worker
service that add special routes for login and password reset.
See https://github.com/product-os/jellyfish/pull/7774

Change-type: major
Signed-off-by: Lucian Buzzo lucian.buzzo@gmail.com