### PR TITLE
Fix `Kernel.defaults` signature

### DIFF
--- a/test/integration/views.spec.ts
+++ b/test/integration/views.spec.ts
@@ -45,7 +45,9 @@ describe('views', () => {
 
 		test('should preserve template interpolations in schema properties', () => {
 			const schema = views.getSchema(
-				Kernel.defaults({
+				// TS-TODO: using `ViewData` here does not typecheck because
+				// of the `$eval`
+				Kernel.defaults<any>({
 					type: 'view@1.0.0',
 					version: '1.0.0',
 					data: {


### PR DESCRIPTION
The current signature defines that the method returns a partial contract while in fact it returns a full contract with only the ID undefined.

Unfortunately this is a major change as it is necessary to change the generic arguments.

Change-type: major
Signed-off-by: Carol Schulze <carol@balena.io>