### PR TITLE
Refactor `SqlQueryOptions`/`BackendQueryOptions` and export the refactored `QueryOptions` type

### DIFF
--- a/lib/backend/postgres/index.ts
+++ b/lib/backend/postgres/index.ts
@@ -15,6 +15,7 @@ import * as skhema from 'skhema';
 import type { Cache } from './../../cache';
 import { Context, Database, Query, TransactionIsolation } from '../../context';
 import * as errors from '../../errors';
+import type { QueryOptions } from '../../kernel';
 import * as cards from './cards';
 import * as jsonschema2sql from './jsonschema2sql';
 import * as links from './links';
@@ -22,7 +23,6 @@ import type {
 	BackendQueryOptions,
 	SearchFieldDef,
 	SelectObject,
-	SqlQueryOptions,
 } from './types';
 import * as streams from './streams';
 import * as utils from './utils';
@@ -80,7 +80,7 @@ export const isIgnorableInitError = (code: string): boolean => {
 /*
  * See https://github.com/product-os/jellyfish/issues/2401
  */
-const MAXIMUM_QUERY_LIMIT = 1000;
+export const MAXIMUM_QUERY_LIMIT = 1000;
 
 // Amount of time to wait before retrying connect
 const DEFAULT_CONNECT_RETRY_DELAY = 2000;
@@ -90,7 +90,7 @@ export const compileSchema = (
 	table: string,
 	select: SelectObject,
 	schema: JsonSchema,
-	options: SqlQueryOptions,
+	options: BackendQueryOptions,
 ): { query: string; queryGenTime: number } => {
 	const queryGenStart = performance.now();
 	let query = null;
@@ -1196,7 +1196,7 @@ export class PostgresBackend implements Database {
 	async stream(
 		select: SelectObject,
 		schema: JsonSchema,
-		options: SqlQueryOptions = {},
+		options: QueryOptions = {},
 	): Promise<streams.Stream> {
 		nativeAssert(!!this.streamClient, 'Stream client must be initialized');
 		/*

--- a/lib/backend/postgres/jsonschema2sql/index.ts
+++ b/lib/backend/postgres/jsonschema2sql/index.ts
@@ -1,7 +1,7 @@
 import type { JsonSchema } from '@balena/jellyfish-types';
 import * as _ from 'lodash';
 import type { Context } from '../../../context';
-import type { SqlQueryOptions } from '../types';
+import type { BackendQueryOptions } from '../types';
 import { SelectMap } from './select-map';
 import { SqlQuery } from './sql-query';
 
@@ -10,7 +10,7 @@ export const compile = (
 	table: string,
 	select: any,
 	schema: JsonSchema,
-	options: SqlQueryOptions = {},
+	options: BackendQueryOptions,
 ) => {
 	return SqlQuery.fromSchema(
 		context,

--- a/lib/backend/postgres/types.ts
+++ b/lib/backend/postgres/types.ts
@@ -1,4 +1,4 @@
-import type { SqlPath } from './jsonschema2sql/sql-path';
+import type { QueryOptions } from '../../';
 import type { PostgresBackend } from '.';
 
 export type DatabaseBackend = PostgresBackend;
@@ -18,54 +18,12 @@ export interface SelectObject {
 	properties?: { [key: string]: any };
 }
 
-export interface SqlQueryOptions {
-	/*
-	 an array denoting the current path in the JSON
-	 schema. Used to produce useful error messages when nesting
-	 SqlQuery instances.
-	*/
-	parentJsonPath?: string[];
-
-	/*
-	 an instance of `SqlPath` denoting the current SQL
-	 field path. This is used when creating a child SqlQuery that
-	 refers to a different table. See {@link SqlQuery#buildQueryFromCorrelatedSchema}.
-	*/
-	parentPath?: SqlPath;
+export interface BackendQueryOptions extends Omit<QueryOptions, 'mask'> {
+	limit: number;
 
 	/*
 	 a string that is used as the initial value for
 	 `this.filter`. Useful for constraints with placeholders.
 	*/
 	extraFilter?: string;
-
-	/*
-   path to field that should be used for sorting
-	*/
-	sortBy?: string | string[];
-
-	/*
-   the direction results should be sorted in
-	*/
-	sortDir?: 'asc' | 'desc';
-
-	/*
-   the number of records to skip when querying results
-	*/
-	skip?: number;
-
-	/*
-   the maximum number of records that should be returned by the query
-	*/
-	limit?: number;
-
-	// TS-TODO: strongly type this option
-	links?: any;
-}
-
-export interface BackendQueryOptions extends SqlQueryOptions {
-	limit: number;
-
-	// if true, the query parameters will be logged on every request
-	profile?: boolean;
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,5 +5,5 @@ export * as contractMixins from './contracts/mixins';
 // Remove this alias as soon as uses in depending packages have been removed.
 export * as cardMixins from './contracts/mixins';
 export * as errors from './errors';
-export { Kernel } from './kernel';
+export { Kernel, QueryOptions } from './kernel';
 export * as testUtils from './test-utils';

--- a/test/integration/backend/postgres/jsonschema2sql/index.spec.ts
+++ b/test/integration/backend/postgres/jsonschema2sql/index.spec.ts
@@ -134,7 +134,10 @@ const runner = async ({
 	/*
 	 * 3. Query the elements back using our translator.
 	 */
-	const query = jsonschema2sql.compile(context, table, {}, schema, options);
+	const query = jsonschema2sql.compile(context, table, {}, schema, {
+		limit: 1000,
+		...options,
+	});
 
 	/*
 	 * 4. Return the results.


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Carol Schulze <carol@balena.io>