### PR TITLE
Add and export StreamChange type

### DIFF
--- a/lib/backend/index.ts
+++ b/lib/backend/index.ts
@@ -1,1 +1,5 @@
-export { PostgresBackend, PostgresBackendOptions } from './postgres';
+export {
+	PostgresBackend,
+	PostgresBackendOptions,
+	StreamChange,
+} from './postgres';

--- a/lib/backend/postgres/index.ts
+++ b/lib/backend/postgres/index.ts
@@ -26,6 +26,7 @@ import type {
 } from './types';
 import * as streams from './streams';
 import * as utils from './utils';
+export type { StreamChange } from './streams';
 
 // tslint:disable-next-line: no-var-requires
 const { version: coreVersion } = require('../../../package.json');

--- a/lib/backend/postgres/streams.ts
+++ b/lib/backend/postgres/streams.ts
@@ -1,5 +1,6 @@
 import * as metrics from '@balena/jellyfish-metrics';
 import type { JsonSchema } from '@balena/jellyfish-types';
+import type { Contract } from '@balena/jellyfish-types/build/core';
 import { EventEmitter } from 'events';
 import * as _ from 'lodash';
 import { Notification } from 'pg';
@@ -13,6 +14,13 @@ import {
 import type { QueryOptions } from '../..';
 import type { BackendQueryOptions, SelectObject } from './types';
 import * as backend from '.';
+
+export interface StreamChange {
+	id: string;
+	contractType: string;
+	type: 'update' | 'insert' | 'delete' | 'unmatch';
+	after?: Contract;
+}
 
 interface EventPayload {
 	id: any;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-export { PostgresBackendOptions } from './backend';
+export { PostgresBackendOptions, StreamChange } from './backend';
 export { Cache } from './cache';
 export { CONTRACTS, CARDS } from './contracts';
 export * as contractMixins from './contracts/mixins';


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

---

Add and export the `StreamChange` type. This type is currently used in `apps/server` in the main JF repo and is defined in `jellyfish-types`. This is another step in dropping `jellyfish-types`.

@Ereski Let me know if you think there is a better place to put this type.