### PR TITLE
Use `allOf` for merging schemas instead of `skhema.merge`

### DIFF
--- a/lib/authorization/utils.ts
+++ b/lib/authorization/utils.ts
@@ -1,7 +1,6 @@
 import type { JsonSchema } from '@balena/jellyfish-types';
 import jsone = require('json-e');
 import * as _ from 'lodash';
-import jsonSchema from '../json-schema';
 
 // Recursively applies an authorization schema to $$links queries,
 // ensuring that authorization can't be escaped by using a relational query.
@@ -24,10 +23,9 @@ export const applyAuthorizationSchemaToLinks = (
 			const links = schema.$$links!;
 			for (const [linkType, linkSchema] of Object.entries(links)) {
 				applyAuthorizationSchemaToLinks(linkSchema, authorizationSchema);
-				links[linkType] = jsonSchema.merge([
-					authorizationSchema as any,
-					linkSchema as any,
-				]) as JsonSchema;
+				links[linkType] = {
+					allOf: [authorizationSchema, linkSchema],
+				};
 			}
 		}
 

--- a/lib/kernel.ts
+++ b/lib/kernel.ts
@@ -1040,10 +1040,9 @@ export class Kernel {
 		querySchema = await preprocessQuerySchema(querySchema);
 
 		if (options.mask) {
-			querySchema = jsonSchema.merge([
-				querySchema as any,
-				options.mask as any,
-			]) as JsonSchema;
+			querySchema = {
+				allOf: [querySchema, options.mask],
+			};
 		}
 
 		const { actor, scope } = await resolveActorAndScopeFromSessionId(
@@ -1170,10 +1169,9 @@ export class Kernel {
 		querySchema = await preprocessQuerySchema(querySchema);
 
 		if (options.mask) {
-			querySchema = jsonSchema.merge([
-				querySchema as any,
-				options.mask as any,
-			]) as JsonSchema;
+			querySchema = {
+				allOf: [querySchema, options.mask],
+			};
 		}
 
 		const authorizedQuerySchema = await authorization.authorizeQuery(
@@ -1278,10 +1276,9 @@ const setupStreamEventHandlers = async (
 		let querySchema = await preprocessQuerySchema(payload.schema);
 
 		if (payload.options?.mask) {
-			querySchema = jsonSchema.merge([
-				querySchema as any,
-				payload.options?.mask as any,
-			]) as JsonSchema;
+			querySchema = {
+				allOf: [querySchema, payload.options?.mask],
+			};
 		}
 
 		const authorizedQuerySchema = await authorization.authorizeQuery(

--- a/lib/views.ts
+++ b/lib/views.ts
@@ -1,7 +1,6 @@
 import type { JsonSchema } from '@balena/jellyfish-types';
 import type { ViewContract } from '@balena/jellyfish-types/build/core';
 import * as _ from 'lodash';
-import jsonSchema from './json-schema';
 
 /**
  * @summary Get the schema of a view contract
@@ -31,5 +30,5 @@ export const getViewContractSchema = (
 		});
 	}
 
-	return jsonSchema.merge(conjunctions as any) as JsonSchema;
+	return { allOf: conjunctions };
 };


### PR DESCRIPTION
`skhema.merge` is bugged and merging provides marginal benefits at the
expense of additional CPU load.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>