### PR TITLE
Apply mask to query with view

### DIFF
--- a/lib/backend/postgres/streams.ts
+++ b/lib/backend/postgres/streams.ts
@@ -239,7 +239,7 @@ export class Stream extends EventEmitter {
 	async query(
 		select: SelectObject,
 		schema: JsonSchema,
-		options: Partial<BackendQueryOptions>,
+		options?: Partial<BackendQueryOptions>,
 	) {
 		// Query the cards with the IDs so we can add them to
 		// `this.seenCardIds`


### PR DESCRIPTION
Change-type: patch

---

Mask is not applied properly when calling `stream.emit('query', ...)`.