### PR TITLE
Use latest version of jellyfish-logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@balena/jellyfish-assert": "^1.2.15",
     "@balena/jellyfish-environment": "^9.1.0",
-    "@balena/jellyfish-logger": "^4.0.37",
+    "@balena/jellyfish-logger": "^5.0.0",
     "@balena/jellyfish-metrics": "^2.0.37",
     "bluebird": "^3.7.2",
     "fast-equals": "^2.0.4",


### PR DESCRIPTION
This major version of the logger no longer handles uncaught exceptions, which would result in mangled and unreadable log messages.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>