### PR TITLE
Revert "Use `allOf` for merging schemas instead of `skhema.merge`"

### DIFF
--- a/lib/authorization/utils.ts
+++ b/lib/authorization/utils.ts
@@ -1,6 +1,7 @@
 import type { JsonSchema } from '@balena/jellyfish-types';
 import jsone = require('json-e');
 import * as _ from 'lodash';
+import jsonSchema from '../json-schema';
 
 // Recursively applies an authorization schema to $$links queries,
 // ensuring that authorization can't be escaped by using a relational query.
@@ -23,9 +24,10 @@ export const applyAuthorizationSchemaToLinks = (
 			const links = schema.$$links!;
 			for (const [linkType, linkSchema] of Object.entries(links)) {
 				applyAuthorizationSchemaToLinks(linkSchema, authorizationSchema);
-				links[linkType] = {
-					allOf: [authorizationSchema, linkSchema],
-				};
+				links[linkType] = jsonSchema.merge([
+					authorizationSchema as any,
+					linkSchema as any,
+				]) as JsonSchema;
 			}
 		}
 

--- a/lib/kernel.ts
+++ b/lib/kernel.ts
@@ -567,6 +567,8 @@ export class Kernel {
 			queryOptions.sortDir = 'desc';
 		}
 
+		schema.required = Object.keys(schema.properties!);
+
 		const results = await this.query<T>(context, session, schema, queryOptions);
 
 		context.assertInternal(

--- a/lib/kernel.ts
+++ b/lib/kernel.ts
@@ -1038,9 +1038,10 @@ export class Kernel {
 		querySchema = await preprocessQuerySchema(querySchema);
 
 		if (options.mask) {
-			querySchema = {
-				allOf: [querySchema, options.mask],
-			};
+			querySchema = jsonSchema.merge([
+				querySchema as any,
+				options.mask as any,
+			]) as JsonSchema;
 		}
 
 		const { actor, scope } = await resolveActorAndScopeFromSessionId(
@@ -1167,9 +1168,10 @@ export class Kernel {
 		querySchema = await preprocessQuerySchema(querySchema);
 
 		if (options.mask) {
-			querySchema = {
-				allOf: [querySchema, options.mask],
-			};
+			querySchema = jsonSchema.merge([
+				querySchema as any,
+				options.mask as any,
+			]) as JsonSchema;
 		}
 
 		const authorizedQuerySchema = await authorization.authorizeQuery(
@@ -1280,9 +1282,10 @@ const setupStreamEventHandlers = async (
 			let querySchema = await preprocessQuerySchema(payload.schema);
 
 			if (payload.options?.mask) {
-				querySchema = {
-					allOf: [querySchema, payload.options?.mask],
-				};
+				querySchema = jsonSchema.merge([
+					querySchema as any,
+					payload.options!.mask as any,
+				]) as JsonSchema;
 			}
 
 			const authorizedQuerySchema = await authorization.authorizeQuery(

--- a/lib/views.ts
+++ b/lib/views.ts
@@ -1,6 +1,7 @@
 import type { JsonSchema } from '@balena/jellyfish-types';
 import type { ViewContract } from '@balena/jellyfish-types/build/core';
 import * as _ from 'lodash';
+import jsonSchema from './json-schema';
 
 /**
  * @summary Get the schema of a view contract
@@ -30,5 +31,5 @@ export const getViewContractSchema = (
 		});
 	}
 
-	return { allOf: conjunctions };
+	return jsonSchema.merge(conjunctions as any) as JsonSchema;
 };

--- a/test/integration/kernel.spec.ts
+++ b/test/integration/kernel.spec.ts
@@ -654,7 +654,7 @@ describe('Kernel', () => {
 							properties: {
 								slug: {
 									type: 'string',
-									enum: ['user', 'type'],
+									const: ['user', 'type'],
 								},
 								type: {
 									type: 'string',

--- a/test/integration/views.spec.ts
+++ b/test/integration/views.spec.ts
@@ -31,7 +31,14 @@ describe('views', () => {
 
 			expect(schema).toEqual({
 				type: 'object',
-				properties: { foo: { type: 'string', const: { $eval: 'user.slug' } } },
+				properties: {
+					foo: {
+						type: 'string',
+						const: {
+							$eval: 'user.slug',
+						},
+					},
+				},
 				required: ['foo'],
 			});
 		});
@@ -61,7 +68,13 @@ describe('views', () => {
 
 			expect(schema).toEqual({
 				type: 'object',
-				properties: { foo: { type: { $eval: 'user.type' } } },
+				properties: {
+					foo: {
+						type: {
+							$eval: 'user.type',
+						},
+					},
+				},
 				required: ['foo'],
 			});
 		});
@@ -105,18 +118,16 @@ describe('views', () => {
 			);
 
 			expect(schema).toEqual({
-				allOf: [
-					{
-						type: 'object',
-						properties: { foo: { type: 'string', minLength: 1 } },
-						required: ['foo'],
+				type: 'object',
+				additionalProperties: true,
+				properties: {
+					foo: {
+						type: 'string',
+						minLength: 1,
+						maxLength: 5,
 					},
-					{
-						type: 'object',
-						properties: { foo: { type: 'string', maxLength: 5 } },
-						required: ['foo'],
-					},
-				],
+				},
+				required: ['foo'],
 			});
 		});
 
@@ -160,18 +171,16 @@ describe('views', () => {
 			);
 
 			expect(schema).toEqual({
-				allOf: [
-					{
-						type: 'object',
-						properties: { foo: { type: 'string', minLength: 1 } },
-						required: ['foo'],
+				type: 'object',
+				additionalProperties: true,
+				properties: {
+					foo: {
+						type: 'string',
+						minLength: 1,
+						maxLength: 5,
 					},
-					{
-						type: 'object',
-						properties: { foo: { type: 'string', maxLength: 5 } },
-						required: ['foo'],
-					},
-				],
+				},
+				required: ['foo'],
 			});
 		});
 
@@ -214,20 +223,28 @@ describe('views', () => {
 			);
 
 			expect(schema).toEqual({
-				allOf: [
+				type: 'object',
+				additionalProperties: true,
+				anyOf: [
 					{
-						anyOf: [
-							{
-								type: 'object',
-								properties: { type: { type: 'string', const: 'view' } },
-								required: ['type'],
+						type: 'object',
+						properties: {
+							type: {
+								type: 'string',
+								const: 'view',
 							},
-							{
-								type: 'object',
-								properties: { type: { type: 'string', const: 'action' } },
-								required: ['type'],
+						},
+						required: ['type'],
+					},
+					{
+						type: 'object',
+						properties: {
+							type: {
+								type: 'string',
+								const: 'action',
 							},
-						],
+						},
+						required: ['type'],
 					},
 				],
 			});
@@ -273,20 +290,28 @@ describe('views', () => {
 			);
 
 			expect(schema).toEqual({
-				allOf: [
+				type: 'object',
+				additionalProperties: true,
+				anyOf: [
 					{
-						anyOf: [
-							{
-								type: 'object',
-								properties: { type: { type: 'string', const: 'view' } },
-								required: ['type'],
+						type: 'object',
+						properties: {
+							type: {
+								type: 'string',
+								const: 'view',
 							},
-							{
-								type: 'object',
-								properties: { type: { type: 'string', const: 'action' } },
-								required: ['type'],
+						},
+						required: ['type'],
+					},
+					{
+						type: 'object',
+						properties: {
+							type: {
+								type: 'string',
+								const: 'action',
 							},
-						],
+						},
+						required: ['type'],
 					},
 				],
 			});
@@ -359,30 +384,36 @@ describe('views', () => {
 			);
 
 			expect(schema).toEqual({
-				allOf: [
+				type: 'object',
+				additionalProperties: true,
+				properties: {
+					foo: {
+						type: 'string',
+						minLength: 1,
+						maxLength: 5,
+					},
+				},
+				required: ['foo'],
+				anyOf: [
 					{
 						type: 'object',
-						properties: { foo: { type: 'string', minLength: 1 } },
-						required: ['foo'],
+						properties: {
+							type: {
+								type: 'string',
+								const: 'view@1.0.0',
+							},
+						},
+						required: ['type'],
 					},
 					{
 						type: 'object',
-						properties: { foo: { type: 'string', maxLength: 5 } },
-						required: ['foo'],
-					},
-					{
-						anyOf: [
-							{
-								type: 'object',
-								properties: { type: { type: 'string', const: 'view@1.0.0' } },
-								required: ['type'],
+						properties: {
+							type: {
+								type: 'string',
+								const: 'action',
 							},
-							{
-								type: 'object',
-								properties: { type: { type: 'string', const: 'action' } },
-								required: ['type'],
-							},
-						],
+						},
+						required: ['type'],
 					},
 				],
 			});


### PR DESCRIPTION
This reverts commit 23eefb30244cc78cb1ffdc667519d2fe7166abd8.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>