### PR TITLE
Mixins: Stop using `$events` in formulas

### DIFF
--- a/lib/contracts/mixins/with-events.ts
+++ b/lib/contracts/mixins/with-events.ts
@@ -1,6 +1,8 @@
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 import { uiSchemaDef } from './ui-schema-defs';
 
+const eventsPartial = `FILTER(contract.links['is attached to'], function (c) { return c.type !== 'create@1.0.0' && c.type !== 'update@1.0.0' })`;
+
 // This mixin defines all common fields in cards that support
 // attached events (i.e. 'timelines')
 export function withEvents(slug: string, type: string): ContractDefinition {
@@ -15,30 +17,30 @@ export function withEvents(slug: string, type: string): ContractDefinition {
 						items: {
 							type: 'string',
 						},
-						$$formula: "AGGREGATE($events, 'tags')",
+						$$formula: `AGGREGATE(${eventsPartial}, 'tags')`,
 						fullTextSearch: true,
 					},
 					data: {
 						properties: {
 							participants: {
 								type: 'array',
-								$$formula: "AGGREGATE($events, 'data.actor')",
+								$$formula: `AGGREGATE(${eventsPartial}, 'participants')`,
 							},
 							mentionsUser: {
 								type: 'array',
-								$$formula: "AGGREGATE($events, 'data.payload.mentionsUser')",
+								$$formula: `AGGREGATE(${eventsPartial}, 'data.payload.mentionsUser')`,
 							},
 							alertsUser: {
 								type: 'array',
-								$$formula: "AGGREGATE($events, 'data.payload.alertsUser')",
+								$$formula: `AGGREGATE(${eventsPartial}, 'data.payload.alertsUser')`,
 							},
 							mentionsGroup: {
 								type: 'array',
-								$$formula: "AGGREGATE($events, 'data.payload.mentionsGroup')",
+								$$formula: `AGGREGATE(${eventsPartial}, 'data.payload.mentionsGroup')`,
 							},
 							alertsGroup: {
 								type: 'array',
-								$$formula: "AGGREGATE($events, 'data.payload.alertsGroup')",
+								$$formula: `AGGREGATE(${eventsPartial}, 'data.payload.alertsGroup')`,
 							},
 						},
 					},

--- a/lib/contracts/org.ts
+++ b/lib/contracts/org.ts
@@ -6,13 +6,6 @@ export const org = {
 		schema: {
 			type: 'object',
 			properties: {
-				tags: {
-					type: 'array',
-					items: {
-						type: 'string',
-					},
-					$$formula: "AGGREGATE($events, 'tags')",
-				},
 				markers: {
 					type: 'array',
 					items: {


### PR DESCRIPTION
`$events` is a shorthand for getting whisper and message contracts from
a timeline, and will be deprecated in future versions of Jellyscript.
The current implementation of `$events` uses a standalone AST parsing algorithm which
needs to be removed.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>