### PR TITLE
mixins: Add unit test for .withEvents()

### DIFF
--- a/lib/contracts/mixins/with-events.ts
+++ b/lib/contracts/mixins/with-events.ts
@@ -1,7 +1,7 @@
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 import { uiSchemaDef } from './ui-schema-defs';
 
-const eventsPartial = `FILTER(contract.links['is attached to'], function (c) { return c && c.type && c.type !== 'create@1.0.0' && c.type !== 'update@1.0.0' })`;
+const eventsPartial = `FILTER(contract.links['has attached element'], function (c) { return c && c.type && c.type !== 'create@1.0.0' && c.type !== 'update@1.0.0' })`;
 
 // This mixin defines all common fields in cards that support
 // attached events (i.e. 'timelines')

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "devDependencies": {
     "@balena/jellyfish-config": "^2.0.2",
+    "@balena/jellyfish-jellyscript": "^5.1.51",
     "@balena/jellyfish-types": "^2.0.0",
     "@balena/lint": "^6.2.0",
     "@json-schema-org/tests": "^1.0.0",

--- a/test/unit/mixins.spec.ts
+++ b/test/unit/mixins.spec.ts
@@ -1,0 +1,37 @@
+import { cardMixins } from '../../lib';
+import type { JsonSchema } from '@balena/jellyfish-types';
+import { evaluateObject } from '@balena/jellyfish-jellyscript';
+
+describe('cardMixins', () => {
+	describe('.withEvents()', () => {
+		it('should create a valid formula', () => {
+			const typeContract = cardMixins.withEvents('test-type', 'type');
+			const schema: JsonSchema = typeContract.data.schema as any;
+			const sample: any = {
+				name: 'sample contract',
+				type: 'test-type',
+				slug: 'test-sample',
+				links: {
+					'has attached element': [
+						{
+							type: 'create',
+							slug: 'foo-1',
+						},
+						{
+							type: 'update@1.0.0',
+							slug: 'foo-2',
+						},
+						{
+							type: 'message@1.0.0',
+							slug: 'foo-3',
+							tags: ['test-tag'],
+						},
+					],
+				},
+			};
+			const result = evaluateObject(schema, sample);
+
+			expect(result.tags).toEqual(['test-tag']);
+		});
+	});
+});


### PR DESCRIPTION
Firstly, this PR fixes the incorrect link verb for traversing event contracts in the `.withEvent()` mixin.
Secondly, this PR adds a simple unit test to sanity check the formula used for aggregating values in the `withEvents()` mixin, alongside updates to jellyscript. 

This change highlights that the core should probably not be providing mixins, especially with functionality that it doesn't provide or handle directly ($$formula fields). 
In the future, we should consider hoisting mixins into the worker module to improve feature separation and make the system less brittle.
