### PR TITLE
mixins: use initial value when aggregating tags

### DIFF
--- a/lib/contracts/mixins/with-events.ts
+++ b/lib/contracts/mixins/with-events.ts
@@ -17,7 +17,7 @@ export function withEvents(slug: string, type: string): ContractDefinition {
 						items: {
 							type: 'string',
 						},
-						$$formula: `AGGREGATE(${eventsPartial}, 'tags')`,
+						$$formula: `AGGREGATE(${eventsPartial}, 'tags', input)`,
 						fullTextSearch: true,
 					},
 					data: {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@balena/jellyfish-config": "^2.0.2",
-    "@balena/jellyfish-jellyscript": "^5.2.1",
+    "@balena/jellyfish-jellyscript": "^5.3.0",
     "@balena/jellyfish-types": "^2.0.0",
     "@balena/lint": "^6.2.0",
     "@json-schema-org/tests": "^1.0.0",

--- a/test/unit/mixins.spec.ts
+++ b/test/unit/mixins.spec.ts
@@ -11,6 +11,7 @@ describe('cardMixins', () => {
 				name: 'sample contract',
 				type: 'test-type',
 				slug: 'test-sample',
+				tags: ['foo'],
 				links: {
 					'has attached element': [
 						{
@@ -31,7 +32,7 @@ describe('cardMixins', () => {
 			};
 			const result = evaluateObject(schema, sample);
 
-			expect(result.tags).toEqual(['test-tag']);
+			expect(result.tags).toEqual(['foo', 'test-tag']);
 		});
 	});
 });


### PR DESCRIPTION
This change ensures that the initial value for tags is kept when aggregating tags.
Previously, if a tag was added directly, it would be overriden by the
AGGREGATE.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>