### PR TITLE
Increase the default number of uses before recycling a DB connection

### DIFF
--- a/lib/backend/postgres/index.ts
+++ b/lib/backend/postgres/index.ts
@@ -204,7 +204,7 @@ const defaultPgOptions: Partial<PostgresBackendOptions> = {
 	connectionTimeoutMillis: 30 * 1000,
 	keepAlive: true,
 	max: 10, // same as default https://github.com/brianc/node-postgres/blob/master/packages/pg-pool/index.js#L84
-	maxUses: 7500,
+	maxUses: 15000,
 };
 
 /*


### PR DESCRIPTION
From 7500 to 30000.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>